### PR TITLE
fix: override data from db with data from blockchain

### DIFF
--- a/src/Item/Item.router.ts
+++ b/src/Item/Item.router.ts
@@ -103,9 +103,9 @@ export class ItemRouter extends Router {
       const remoteItem = await collectionAPI.fetchItemByBlockchainId(
         dbItem.blockchain_item_id
       )
-      dbItem = {
-        ...dbItem,
-        ...remoteItem
+      if (remoteItem) {
+        const [item] = new Bridge().consolidateItems([dbItem], [remoteItem])
+        return item
       }
     }
 


### PR DESCRIPTION
Override data from nested entities with data from parent (that has been merged with data from db + blockchain)

To avoid stuff like this:

<img width="932" alt="Screen Shot 2020-10-30 at 5 42 35 PM" src="https://user-images.githubusercontent.com/2781777/97756320-73ebf100-1ad9-11eb-9989-f4db2f9860ac.png">
