### PR TITLE
feat: removed unique constraint from creation_coords column on projects table

### DIFF
--- a/migrations/1619003436435_remove-unique-creation-coords.ts
+++ b/migrations/1619003436435_remove-unique-creation-coords.ts
@@ -1,0 +1,20 @@
+import { MigrationBuilder } from 'node-pg-migrate'
+import { Project } from '../src/Project'
+
+const tableName = Project.tableName
+const constraintToRemove = 'projects_creation_coords_key'
+
+//This query will delete all the deleted project created from builder in world so it can create the constraint again
+const sqlQuery = "DELETE FROM projects where is_deleted = true and creation_coords is not null"
+
+export const up = (pgm: MigrationBuilder) => {
+  pgm.dropConstraint(tableName, constraintToRemove)
+}
+
+
+export const down = (pgm: MigrationBuilder) => {
+  pgm.sql(sqlQuery)
+  pgm.addConstraint(tableName, constraintToRemove, 'unique (creation_coords)')
+}
+
+


### PR DESCRIPTION
# What?
This PR will remove the unique constraint from creation_coords.

# Why? 
I just realized that if someone delete the project from the builder, because he want a fresh start, we should be able to introduce a new row with the same coords so it can still have a project with the current save.

This way we could have several rows with the same coords