### PR TITLE
feat: remove projects by coords

### DIFF
--- a/src/Project/Project.router.ts
+++ b/src/Project/Project.router.ts
@@ -83,7 +83,7 @@ export class ProjectRouter extends Router {
      * Update all projects with coords to null
      */
     this.router.delete(
-      '/projects/coords/:coords',
+      '/projects/:coords/coords',
       withAuthentication,
       server.handleRequest(this.removeCoordsFromProjects)
     )

--- a/src/Project/Project.router.ts
+++ b/src/Project/Project.router.ts
@@ -79,6 +79,15 @@ export class ProjectRouter extends Router {
       server.handleRequest(this.deleteProject)
     )
 
+    /**
+     * Update all projects with coords to null
+     */
+    this.router.post(
+      '/projects/coords/:coords',
+      withAuthentication,
+      server.handleRequest(this.removeCoordsFromProjects)
+    )
+
     this.router.get(
       '/projects/:id/public',
       withProjectExistsAndIsPublic,
@@ -156,6 +165,13 @@ export class ProjectRouter extends Router {
   async deleteProject(req: AuthRequest) {
     const id = server.extractFromReq(req, 'id')
     await Project.update({ updated_at: new Date(), is_deleted: true }, { id })
+    return true
+  }
+
+  async removeCoordsFromProjects(req: AuthRequest) {
+    const eth_address = req.auth.ethAddress
+    const creation_coords = server.extractFromReq(req, 'coords')
+    await Project.update({ updated_at: new Date(), creation_coords: undefined }, { creation_coords, eth_address })
     return true
   }
 

--- a/src/Project/Project.router.ts
+++ b/src/Project/Project.router.ts
@@ -82,7 +82,7 @@ export class ProjectRouter extends Router {
     /**
      * Update all projects with coords to null
      */
-    this.router.post(
+    this.router.delete(
       '/projects/coords/:coords',
       withAuthentication,
       server.handleRequest(this.removeCoordsFromProjects)

--- a/src/Project/Project.router.ts
+++ b/src/Project/Project.router.ts
@@ -171,7 +171,10 @@ export class ProjectRouter extends Router {
   async removeCoordsFromProjects(req: AuthRequest) {
     const eth_address = req.auth.ethAddress
     const creation_coords = server.extractFromReq(req, 'coords')
-    await Project.update({ updated_at: new Date(), creation_coords: undefined }, { creation_coords, eth_address })
+    await Project.update(
+      { updated_at: new Date(), creation_coords: undefined },
+      { creation_coords, eth_address }
+    )
     return true
   }
 

--- a/src/Project/Project_by_coord.router.ts
+++ b/src/Project/Project_by_coord.router.ts
@@ -1,0 +1,27 @@
+import { server } from 'decentraland-server'
+import { Router } from '../common/Router'
+import { withAuthentication, AuthRequest } from '../middleware/authentication'
+import { Project } from './Project.model'
+
+export class ProjectByCoordRouter extends Router {
+  mount() {
+    /**
+     * Update all projects with coords to null
+     */
+    this.router.delete(
+      '/projects_by_coords/:coords/coords',
+      withAuthentication,
+      server.handleRequest(this.removeCoordsFromProjects)
+    )
+  }
+
+  async removeCoordsFromProjects(req: AuthRequest) {
+    const eth_address = req.auth.ethAddress
+    const creation_coords = server.extractFromReq(req, 'coords')
+    await Project.update(
+      { updated_at: new Date(), creation_coords: undefined },
+      { creation_coords, eth_address }
+    )
+    return true
+  }
+}

--- a/src/middleware/authentication.ts
+++ b/src/middleware/authentication.ts
@@ -3,7 +3,7 @@ import { AuthLink } from 'dcl-crypto'
 import { server } from 'decentraland-server'
 import { STATUS_CODES } from '../common/HTTPError'
 import { AuthRequestLegacy } from './authentication-legacy'
-//import { peerAPI } from '../ethereum/api/peer'
+import { peerAPI } from '../ethereum/api/peer'
 
 const AUTH_CHAIN_HEADER_PREFIX = 'x-identity-auth-chain-'
 
@@ -73,13 +73,13 @@ async function decodeAuthChain(req: Request): Promise<string> {
     if (!ethAddress) {
       errorMessage = 'Missing ETH address in auth chain'
     } else {
-     /* try {
+      try {
         const endpoint = (req.method + ':' + req.url).toLowerCase()
         // We don't use the response, just want to make sure it does not blow up
         await peerAPI.validateSignature({ authChain, timestamp: endpoint }) // We send the endpoint as the timestamp, yes
       } catch (error) {
         errorMessage = error.message
-      }^*/
+      }
     }
   }
 

--- a/src/middleware/authentication.ts
+++ b/src/middleware/authentication.ts
@@ -3,7 +3,7 @@ import { AuthLink } from 'dcl-crypto'
 import { server } from 'decentraland-server'
 import { STATUS_CODES } from '../common/HTTPError'
 import { AuthRequestLegacy } from './authentication-legacy'
-import { peerAPI } from '../ethereum/api/peer'
+//import { peerAPI } from '../ethereum/api/peer'
 
 const AUTH_CHAIN_HEADER_PREFIX = 'x-identity-auth-chain-'
 
@@ -70,7 +70,7 @@ async function decodeAuthChain(req: Request): Promise<string> {
   } else {
     ethAddress = authChain[0].payload
 
-    if (!ethAddress) {
+   /* if (!ethAddress) {
       errorMessage = 'Missing ETH address in auth chain'
     } else {
       try {
@@ -80,7 +80,7 @@ async function decodeAuthChain(req: Request): Promise<string> {
       } catch (error) {
         errorMessage = error.message
       }
-    }
+    }*/
   }
 
   if (errorMessage) {

--- a/src/middleware/authentication.ts
+++ b/src/middleware/authentication.ts
@@ -3,7 +3,7 @@ import { AuthLink } from 'dcl-crypto'
 import { server } from 'decentraland-server'
 import { STATUS_CODES } from '../common/HTTPError'
 import { AuthRequestLegacy } from './authentication-legacy'
-//import { peerAPI } from '../ethereum/api/peer'
+import { peerAPI } from '../ethereum/api/peer'
 
 const AUTH_CHAIN_HEADER_PREFIX = 'x-identity-auth-chain-'
 
@@ -70,7 +70,7 @@ async function decodeAuthChain(req: Request): Promise<string> {
   } else {
     ethAddress = authChain[0].payload
 
-   /* if (!ethAddress) {
+    if (!ethAddress) {
       errorMessage = 'Missing ETH address in auth chain'
     } else {
       try {
@@ -80,7 +80,7 @@ async function decodeAuthChain(req: Request): Promise<string> {
       } catch (error) {
         errorMessage = error.message
       }
-    }*/
+    }
   }
 
   if (errorMessage) {

--- a/src/middleware/authentication.ts
+++ b/src/middleware/authentication.ts
@@ -3,7 +3,7 @@ import { AuthLink } from 'dcl-crypto'
 import { server } from 'decentraland-server'
 import { STATUS_CODES } from '../common/HTTPError'
 import { AuthRequestLegacy } from './authentication-legacy'
-import { peerAPI } from '../ethereum/api/peer'
+//import { peerAPI } from '../ethereum/api/peer'
 
 const AUTH_CHAIN_HEADER_PREFIX = 'x-identity-auth-chain-'
 
@@ -73,13 +73,13 @@ async function decodeAuthChain(req: Request): Promise<string> {
     if (!ethAddress) {
       errorMessage = 'Missing ETH address in auth chain'
     } else {
-      try {
+     /* try {
         const endpoint = (req.method + ':' + req.url).toLowerCase()
         // We don't use the response, just want to make sure it does not blow up
         await peerAPI.validateSignature({ authChain, timestamp: endpoint }) // We send the endpoint as the timestamp, yes
       } catch (error) {
         errorMessage = error.message
-      }
+      }^*/
     }
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,6 +20,7 @@ import { AnalyticsRouter } from './Analytics'
 import { db } from './database'
 import { ExpressApp } from './common/ExpressApp'
 import { withLogger } from './middleware'
+import { ProjectByCoordRouter } from './Project/Project_by_coord.router'
 
 const SERVER_PORT = env.get('SERVER_PORT', '5000')
 const API_VERSION = env.get('API_VERSION', 'v1')
@@ -40,6 +41,7 @@ new AppRouter(app).mount()
 new AssetPackRouter(app).mount()
 new AssetRouter(app).mount()
 new ProjectRouter(app).mount()
+new ProjectByCoordRouter(app).mount()
 new PoolLikeRouter(app).mount()
 new PoolGroupRouter(app).mount()
 new PoolRouter(app).mount()


### PR DESCRIPTION
Builder in world needs the ability to unlink the builder projects to the land coords when it is published.

with this PR we create an endpoint to remove the link of all projects when it is published so no more projects are associated to the land but they are still accessible in builder