### PR TITLE
fix: prevent the endpoint to break if an item is missing the content url

### DIFF
--- a/src/ethereum/api/peer.ts
+++ b/src/ethereum/api/peer.ts
@@ -78,18 +78,18 @@ export class PeerAPI {
       urns.length > 0
         ? await this.lambdasClient.fetchWearables({ wearableIds: urns })
         : []
-    return wearables.map(this.toWearable)
+    return wearables.map((wearable) => this.toWearable(wearable))
   }
 
   private toWearable(peerWearable: PeerWearable): Wearable {
     const contents: Record<string, string> = {}
     for (let representation of peerWearable.data.representations) {
       for (let content of representation.contents) {
-        contents[content.key] = content.url.split('/').pop()!
+        contents[content.key] = this.getLastURLPart(content.url)
       }
     }
 
-    contents[THUMBNAIL_PATH] = peerWearable.thumbnail.split('/').pop()!
+    contents[THUMBNAIL_PATH] = this.getLastURLPart(peerWearable.thumbnail)
 
     return {
       ...peerWearable,
@@ -104,6 +104,10 @@ export class PeerAPI {
       },
       contents,
     }
+  }
+
+  private getLastURLPart(url = ''): string {
+    return url.split('/').pop() || ''
   }
 }
 


### PR DESCRIPTION
From
![image](https://user-images.githubusercontent.com/692077/126840857-3d5ca8f8-6440-4376-bcf9-50ea036fae66.png)

to
![image](https://user-images.githubusercontent.com/692077/126841102-a4e17ec7-50ab-44ac-905c-56783d4827e5.png)

