### PR TITLE
feat: Log retries and output a conflict error when the link exists

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,4 @@
 
 npm run migrate:docker up || exit 1
 npm run seed || exit 1
-npm run start || exit 1
+node ./dist/src/server.js || exit 1

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint:fix": "tslint -p tsconfig.json --fix",
     "build": "tsc -p tsconfig.json",
     "watch:build": "tsc -p tsconfig.json --watch",
-    "start": "npm run build && node ./dist/src/server.js",
+    "start": "ts-node src/server.ts",
     "watch:start": "nodemon src/server.ts",
     "migrate": "ts-node ./migrations/migrate.ts",
     "migrate:docker": "./migrations/node-pg-migrate --database-url-var CONNECTION_STRING --migration-file-language ts --migrations-dir /app/migrations --ignore-pattern '\\..*|.*migrate(.ts)?'",
@@ -24,6 +24,9 @@
     "semi": false,
     "singleQuote": true,
     "printWidth": 80
+  },
+  "engines": {
+    "node": ">=10 <=12"
   },
   "dependencies": {
     "@apollo/client": "^3.3.9",

--- a/src/Forum/Forum.router.ts
+++ b/src/Forum/Forum.router.ts
@@ -8,17 +8,18 @@ import { ExpressApp } from '../common/ExpressApp'
 import { withModelExists, withModelAuthorization } from '../middleware'
 import { withAuthentication, AuthRequest } from '../middleware/authentication'
 import { Collection, CollectionAttributes } from '../Collection'
+import { MetricDeclarations } from '../MetricsDeclarations'
 import { createPost } from './client'
 import { ForumPost, forumPostSchema } from './Forum.types'
 
 const validator = getValidator()
 
 export class ForumRouter extends Router {
-  readonly metrics: IMetricsComponent<'dcl_published_collection_forum_post_failed'>
+  readonly metrics: IMetricsComponent<MetricDeclarations>
 
   constructor(
     router: ExpressApp | express.Router,
-    metrics: IMetricsComponent<'dcl_published_collection_forum_post_failed'>
+    metrics: IMetricsComponent<MetricDeclarations>
   ) {
     super(router)
     this.metrics = metrics
@@ -35,7 +36,7 @@ export class ForumRouter extends Router {
       withAuthentication,
       withCollectionExists,
       withCollectionAuthorization,
-      server.handleRequest(this.post)
+      server.handleRequest(this.post.bind(this))
     )
   }
 

--- a/src/Forum/Forum.router.ts
+++ b/src/Forum/Forum.router.ts
@@ -53,6 +53,9 @@ export class ForumRouter extends Router {
 
     const collection = await Collection.findOne(id)
     if (collection.forum_link) {
+      this.metrics.increment(
+        'dcl_published_collection_forum_post_already_exists'
+      )
       throw new HTTPError(
         'Forum post already exists',
         { id, forum_link: collection.forum_link },

--- a/src/Forum/Forum.router.ts
+++ b/src/Forum/Forum.router.ts
@@ -25,11 +25,11 @@ export class ForumRouter extends Router<MetricDeclarations> {
       withAuthentication,
       withCollectionExists,
       withCollectionAuthorization,
-      server.handleRequest(this.post.bind(this))
+      server.handleRequest(this.post)
     )
   }
 
-  async post(req: AuthRequest) {
+  post = async (req: AuthRequest) => {
     const id: string = server.extractFromReq(req, 'id')
     const forumPostJSON: any = server.extractFromReq(req, 'forumPost')
 

--- a/src/Forum/Forum.router.ts
+++ b/src/Forum/Forum.router.ts
@@ -1,29 +1,17 @@
 import { server } from 'decentraland-server'
-import express from 'express'
-import { IMetricsComponent } from '@well-known-components/interfaces'
 import { Router } from '../common/Router'
 import { HTTPError, STATUS_CODES } from '../common/HTTPError'
 import { getValidator } from '../utils/validator'
-import { ExpressApp } from '../common/ExpressApp'
 import { withModelExists, withModelAuthorization } from '../middleware'
 import { withAuthentication, AuthRequest } from '../middleware/authentication'
-import { Collection, CollectionAttributes } from '../Collection'
 import { MetricDeclarations } from '../MetricsDeclarations'
+import { Collection, CollectionAttributes } from '../Collection'
 import { createPost } from './client'
 import { ForumPost, forumPostSchema } from './Forum.types'
 
 const validator = getValidator()
 
-export class ForumRouter extends Router {
-  readonly metrics: IMetricsComponent<MetricDeclarations>
-
-  constructor(
-    router: ExpressApp | express.Router,
-    metrics: IMetricsComponent<MetricDeclarations>
-  ) {
-    super(router)
-    this.metrics = metrics
-  }
+export class ForumRouter extends Router<MetricDeclarations> {
   mount() {
     const withCollectionExists = withModelExists(Collection, 'id')
     const withCollectionAuthorization = withModelAuthorization(Collection)
@@ -54,7 +42,7 @@ export class ForumRouter extends Router {
 
     const collection = await Collection.findOne(id)
     if (collection.forum_link) {
-      this.metrics.increment(
+      this.metrics!.increment(
         'dcl_published_collection_forum_post_already_exists'
       )
       throw new HTTPError(
@@ -70,7 +58,7 @@ export class ForumRouter extends Router {
 
       return forum_link
     } catch (error) {
-      this.metrics.increment('dcl_published_collection_forum_post_failed')
+      this.metrics!.increment('dcl_published_collection_forum_post_failed')
       throw new HTTPError(
         'Error creating forum post',
         { errors: error.message },

--- a/src/Forum/Forum.router.ts
+++ b/src/Forum/Forum.router.ts
@@ -4,6 +4,7 @@ import { HTTPError, STATUS_CODES } from '../common/HTTPError'
 import { getValidator } from '../utils/validator'
 import { withModelExists, withModelAuthorization } from '../middleware'
 import { withAuthentication, AuthRequest } from '../middleware/authentication'
+import { MetricKeys } from '../MetricsDeclarations'
 import { MetricDeclarations } from '../MetricsDeclarations'
 import { Collection, CollectionAttributes } from '../Collection'
 import { createPost } from './client'
@@ -42,9 +43,7 @@ export class ForumRouter extends Router<MetricDeclarations> {
 
     const collection = await Collection.findOne(id)
     if (collection.forum_link) {
-      this.metrics!.increment(
-        'dcl_published_collection_forum_post_already_exists'
-      )
+      this.metrics!.increment(MetricKeys.FORUM_POST_ALREADY_EXISTS)
       throw new HTTPError(
         'Forum post already exists',
         { id, forum_link: collection.forum_link },
@@ -58,7 +57,7 @@ export class ForumRouter extends Router<MetricDeclarations> {
 
       return forum_link
     } catch (error) {
-      this.metrics!.increment('dcl_published_collection_forum_post_failed')
+      this.metrics!.increment(MetricKeys.FORUM_POST_FAILED)
       throw new HTTPError(
         'Error creating forum post',
         { errors: error.message },

--- a/src/MetricsDeclarations.ts
+++ b/src/MetricsDeclarations.ts
@@ -1,0 +1,13 @@
+import { IMetricsComponent } from '@well-known-components/interfaces'
+import { validateMetricsDeclaration } from '@well-known-components/metrics'
+
+export const metricDeclarations = {
+  dcl_published_collection_forum_post_failed: {
+    help: 'Count failed published collection forum posts',
+    type: IMetricsComponent.CounterType,
+    labelNames: ['forum'],
+  },
+}
+
+// type assertions
+validateMetricsDeclaration(metricDeclarations)

--- a/src/MetricsDeclarations.ts
+++ b/src/MetricsDeclarations.ts
@@ -1,13 +1,18 @@
 import { IMetricsComponent } from '@well-known-components/interfaces'
 import { validateMetricsDeclaration } from '@well-known-components/metrics'
 
+export enum MetricKeys {
+  FORUM_POST_FAILED = 'dcl_published_collection_forum_post_failed',
+  FORUM_POST_ALREADY_EXISTS = 'dcl_published_collection_forum_post_already_exists',
+}
+
 export const metricDeclarations = {
-  dcl_published_collection_forum_post_failed: {
+  [MetricKeys.FORUM_POST_FAILED]: {
     help: 'Count failed published collection forum post creation',
     type: IMetricsComponent.CounterType,
     labelNames: [],
   },
-  dcl_published_collection_forum_post_already_exists: {
+  [MetricKeys.FORUM_POST_ALREADY_EXISTS]: {
     help:
       'Count failed published collection forum creation due to already created forum links',
     type: IMetricsComponent.CounterType,

--- a/src/MetricsDeclarations.ts
+++ b/src/MetricsDeclarations.ts
@@ -15,5 +15,7 @@ export const metricDeclarations = {
   },
 }
 
+export type MetricDeclarations = keyof typeof metricDeclarations
+
 // type assertions
 validateMetricsDeclaration(metricDeclarations)

--- a/src/MetricsDeclarations.ts
+++ b/src/MetricsDeclarations.ts
@@ -5,7 +5,7 @@ export const metricDeclarations = {
   dcl_published_collection_forum_post_failed: {
     help: 'Count failed published collection forum posts',
     type: IMetricsComponent.CounterType,
-    labelNames: ['forum'],
+    labelNames: [],
   },
 }
 

--- a/src/MetricsDeclarations.ts
+++ b/src/MetricsDeclarations.ts
@@ -3,7 +3,13 @@ import { validateMetricsDeclaration } from '@well-known-components/metrics'
 
 export const metricDeclarations = {
   dcl_published_collection_forum_post_failed: {
-    help: 'Count failed published collection forum posts',
+    help: 'Count failed published collection forum post creation',
+    type: IMetricsComponent.CounterType,
+    labelNames: [],
+  },
+  dcl_published_collection_forum_post_already_exists: {
+    help:
+      'Count failed published collection forum creation due to already created forum links',
     type: IMetricsComponent.CounterType,
     labelNames: [],
   },

--- a/src/common/ExpressApp.ts
+++ b/src/common/ExpressApp.ts
@@ -1,7 +1,6 @@
 import express from 'express'
 import { collectDefaultMetrics } from 'prom-client'
 import { createTestMetricsComponent } from '@well-known-components/metrics'
-import { getDefaultHttpMetrics } from '@well-known-components/metrics/dist/http'
 
 export class ExpressApp {
   protected app: express.Application
@@ -50,8 +49,7 @@ export class ExpressApp {
     return this
   }
 
-  useMetrics() {
-    const base = createTestMetricsComponent(getDefaultHttpMetrics())
+  useMetrics(base: ReturnType<typeof createTestMetricsComponent>) {
     const register = base.register
 
     const bearerToken = process.env.WKC_METRICS_BEARER_TOKEN

--- a/src/common/HTTPError.ts
+++ b/src/common/HTTPError.ts
@@ -2,6 +2,7 @@ export const STATUS_CODES = {
   ok: 200,
   unauthorized: 401,
   notFound: 404,
+  conflict: 409,
   error: 500,
 }
 export type StatusCode = typeof STATUS_CODES[keyof typeof STATUS_CODES]

--- a/src/common/Router.ts
+++ b/src/common/Router.ts
@@ -1,12 +1,18 @@
 import express = require('express')
+import { IMetricsComponent } from '@well-known-components/interfaces'
 
 import { ExpressApp } from './ExpressApp'
 
-export class Router {
-  protected router: express.Router
+export class Router<M extends string = string> {
+  protected readonly router: express.Router
+  protected readonly metrics: IMetricsComponent<M> | undefined
 
-  constructor(router: ExpressApp | express.Router) {
+  constructor(
+    router: ExpressApp | express.Router,
+    metrics?: IMetricsComponent<M>
+  ) {
     this.router = router instanceof ExpressApp ? router.getRouter() : router
+    this.metrics = metrics
   }
 
   mount(): void {

--- a/src/server.ts
+++ b/src/server.ts
@@ -70,6 +70,7 @@ if (require.main === module) {
 }
 
 async function startServer() {
+  console.log('Connecting database')
   await db.connect()
   return app.listen(SERVER_PORT)
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,6 @@
 import { env } from 'decentraland-commons'
 import { createTestMetricsComponent } from '@well-known-components/metrics'
+import { getDefaultHttpMetrics } from '@well-known-components/metrics/dist/http'
 import { metricDeclarations } from './MetricsDeclarations'
 
 import { AppRouter } from './App'
@@ -30,15 +31,15 @@ const CORS_ORIGIN = env.get('CORS_ORIGIN', '*')
 const CORS_METHOD = env.get('CORS_METHOD', '*')
 
 const app = new ExpressApp()
+const metrics = { ...getDefaultHttpMetrics(), ...metricDeclarations }
+const metricsComponent = createTestMetricsComponent(metrics)
 
 app
   .use(withLogger())
   .useJSON()
   .useVersion(API_VERSION)
   .useCORS(CORS_ORIGIN, CORS_METHOD)
-  .useMetrics()
-
-const metrics = createTestMetricsComponent(metricDeclarations)
+  .useMetrics(metricsComponent)
 
 // Mount routers
 new AppRouter(app).mount()
@@ -53,7 +54,7 @@ new ItemRouter(app).mount()
 new CollectionRouter(app).mount()
 new CommitteeRouter(app).mount()
 new RarityRouter(app).mount()
-new ForumRouter(app, metrics).mount()
+new ForumRouter(app, metricsComponent).mount()
 new ManifestRouter(app).mount()
 new DeploymentRouter(app).mount()
 new S3Router(app).mount()

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,6 @@
 import { env } from 'decentraland-commons'
+import { createTestMetricsComponent } from '@well-known-components/metrics'
+import { metricDeclarations } from './MetricsDeclarations'
 
 import { AppRouter } from './App'
 import { AssetPackRouter } from './AssetPack'
@@ -36,6 +38,8 @@ app
   .useCORS(CORS_ORIGIN, CORS_METHOD)
   .useMetrics()
 
+const metrics = createTestMetricsComponent(metricDeclarations)
+
 // Mount routers
 new AppRouter(app).mount()
 new AssetPackRouter(app).mount()
@@ -49,7 +53,7 @@ new ItemRouter(app).mount()
 new CollectionRouter(app).mount()
 new CommitteeRouter(app).mount()
 new RarityRouter(app).mount()
-new ForumRouter(app).mount()
+new ForumRouter(app, metrics).mount()
 new ManifestRouter(app).mount()
 new DeploymentRouter(app).mount()
 new S3Router(app).mount()
@@ -65,7 +69,6 @@ if (require.main === module) {
 }
 
 async function startServer() {
-  console.log('Connecting database')
   await db.connect()
   return app.listen(SERVER_PORT)
 }


### PR DESCRIPTION
This PR logs the forum post retries and returns a 409 when there's a link for the forum already created for a collection.
It also fixes the entrypoint to avoid re-building the service when starting it.