### PR TITLE
feat: Use redirect for S3 files

### DIFF
--- a/src/S3/S3Router.ts
+++ b/src/S3/S3Router.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express'
 import { server } from 'decentraland-server'
 
 import { Router } from '../common/Router'
+import { getBucketURL } from './s3'
 import { S3AssetPack } from './S3AssetPack'
 import { S3Content } from './S3Content'
 
@@ -12,7 +13,7 @@ export class S3Router extends Router {
      */
     this.router.get(
       '/storage/assetPacks/:filename',
-      this.getHandlerForModel(S3AssetPack)
+      this.getHandlerForAssetType(S3AssetPack)
     )
 
     /**
@@ -20,27 +21,15 @@ export class S3Router extends Router {
      */
     this.router.get(
       '/storage/contents/:filename',
-      this.getHandlerForModel(S3Content, true)
+      this.getHandlerForAssetType(S3Content)
     )
   }
 
-  private getHandlerForModel(
-    Model: typeof S3AssetPack | typeof S3Content,
-    cache: boolean = false
-  ) {
+  private getHandlerForAssetType(Model: typeof S3AssetPack | typeof S3Content) {
+    const model = new Model('')
     return async (req: Request, res: Response) => {
       const filename = server.extractFromReq(req, 'filename')
-      const file = await new Model('').readFile(filename)
-
-      if (file) {
-        res.setHeader('Content-Type', file.ContentType!)
-        if (cache) {
-          res.setHeader('Cache-Control', 'public,max-age=31536000,immutable')
-        }
-        return res.end(file.Body)
-      } else {
-        return res.status(404).send('Could not find file')
-      }
+      return res.redirect(`${getBucketURL()}/${model.getFileKey(filename)}`)
     }
   }
 }

--- a/src/S3/s3.ts
+++ b/src/S3/s3.ts
@@ -171,3 +171,7 @@ export function getFileUploader(
     }),
   })
 }
+
+export const getBucketURL = (): string => {
+  return `https://${BUCKET_NAME}.s3.amazonaws.com`
+}


### PR DESCRIPTION
This PR changes the way we were serving the following endpoints:
- /projects/:id/media/:filename
- /publics/:id/manifest
- /pools/:id/manifest
- /storage/assetPacks/:filename
- /storage/contents/:filename

To respond with a redirect instead of buffering the file before streaming it to the clients.