### PR TITLE
feat: Add cache redirect for other endpoints

### DIFF
--- a/src/Manifest/Manifest.router.ts
+++ b/src/Manifest/Manifest.router.ts
@@ -95,8 +95,11 @@ export class ManifestRouter extends Router {
   getProjectManifest = (req: Request, res: Response) => {
     const id = server.extractFromReq(req, 'id')
     const project = new S3Project(id)
+
+    res.setHeader('Cache-Control', 'public,max-age=31536000,immutable')
     return res.redirect(
-      `${getBucketURL()}/${project.getFileKey(MANIFEST_FILENAME)}`
+      `${getBucketURL()}/${project.getFileKey(MANIFEST_FILENAME)}`,
+      301
     )
   }
 
@@ -125,8 +128,10 @@ export class ManifestRouter extends Router {
   getPoolManifest = (req: Request, res: Response) => {
     const id = server.extractFromReq(req, 'id')
     const project = new S3Project(id)
+    res.setHeader('Cache-Control', 'public,max-age=31536000,immutable')
     return res.redirect(
-      `${getBucketURL()}/${project.getFileKey(POOL_FILENAME)}`
+      `${getBucketURL()}/${project.getFileKey(POOL_FILENAME)}`,
+      301
     )
   }
 

--- a/src/Manifest/Manifest.router.ts
+++ b/src/Manifest/Manifest.router.ts
@@ -96,7 +96,6 @@ export class ManifestRouter extends Router {
   getProjectManifest = (req: Request, res: Response) => {
     const id = server.extractFromReq(req, 'id')
     const project = new S3Project(id)
-
     addInmutableCacheControlHeader(res)
     return res.redirect(
       `${getBucketURL()}/${project.getFileKey(MANIFEST_FILENAME)}`,

--- a/src/Manifest/Manifest.router.ts
+++ b/src/Manifest/Manifest.router.ts
@@ -2,6 +2,7 @@ import { server } from 'decentraland-server'
 import { Request, Response } from 'express'
 
 import { Router } from '../common/Router'
+import { addInmutableCacheControlHeader } from '../common/headers'
 import { HTTPError, STATUS_CODES } from '../common/HTTPError'
 import { getValidator } from '../utils/validator'
 import {
@@ -96,7 +97,7 @@ export class ManifestRouter extends Router {
     const id = server.extractFromReq(req, 'id')
     const project = new S3Project(id)
 
-    res.setHeader('Cache-Control', 'public,max-age=31536000,immutable')
+    addInmutableCacheControlHeader(res)
     return res.redirect(
       `${getBucketURL()}/${project.getFileKey(MANIFEST_FILENAME)}`,
       301
@@ -128,7 +129,7 @@ export class ManifestRouter extends Router {
   getPoolManifest = (req: Request, res: Response) => {
     const id = server.extractFromReq(req, 'id')
     const project = new S3Project(id)
-    res.setHeader('Cache-Control', 'public,max-age=31536000,immutable')
+    addInmutableCacheControlHeader(res)
     return res.redirect(
       `${getBucketURL()}/${project.getFileKey(POOL_FILENAME)}`,
       301

--- a/src/Project/Project.router.ts
+++ b/src/Project/Project.router.ts
@@ -4,6 +4,7 @@ import mimeTypes from 'mime-types'
 import path from 'path'
 
 import { Router } from '../common/Router'
+import { addInmutableCacheControlHeader } from '../common/headers'
 import { HTTPError, STATUS_CODES } from '../common/HTTPError'
 import { getValidator } from '../utils/validator'
 import { withModelExists, withModelAuthorization } from '../middleware'
@@ -191,7 +192,7 @@ export class ProjectRouter extends Router {
         .json(server.sendError({ filename }, 'Invalid filename'))
     }
 
-    res.setHeader('Cache-Control', 'public,max-age=31536000,immutable')
+    addInmutableCacheControlHeader(res)
     return res.redirect(
       `${getBucketURL()}/${project.getFileKey(filename)}`,
       301

--- a/src/Project/Project.router.ts
+++ b/src/Project/Project.router.ts
@@ -191,7 +191,11 @@ export class ProjectRouter extends Router {
         .json(server.sendError({ filename }, 'Invalid filename'))
     }
 
-    return res.redirect(`${getBucketURL()}/${project.getFileKey(filename)}`)
+    res.setHeader('Cache-Control', 'public,max-age=31536000,immutable')
+    return res.redirect(
+      `${getBucketURL()}/${project.getFileKey(filename)}`,
+      301
+    )
   }
 
   async uploadFiles(req: AuthRequest) {

--- a/src/S3/S3Router.ts
+++ b/src/S3/S3Router.ts
@@ -24,16 +24,19 @@ export class S3Router extends Router {
     return `${getBucketURL()}/${model.getFileKey(filename)}`
   }
 
+  private permanentlyRedirectFile(req: Request, res: Response, model: S3Model) {
+    const filename = server.extractFromReq(req, 'filename')
+    res.setHeader('Cache-Control', 'public,max-age=31536000,immutable')
+    return res.redirect(this.buildRedirectUrl(model, filename), 301)
+  }
+
   private handleAssetPacks = (req: Request, res: Response) => {
     const model = new S3AssetPack('')
-    const filename = server.extractFromReq(req, 'filename')
-    return res.redirect(this.buildRedirectUrl(model, filename))
+    this.permanentlyRedirectFile(req, res, model)
   }
 
   private handleContents = (req: Request, res: Response) => {
     const model = new S3Content()
-    const filename = server.extractFromReq(req, 'filename')
-    res.setHeader('Cache-Control', 'public,max-age=31536000,immutable')
-    return res.redirect(this.buildRedirectUrl(model, filename), 301)
+    this.permanentlyRedirectFile(req, res, model)
   }
 }

--- a/src/S3/S3Router.ts
+++ b/src/S3/S3Router.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express'
 import { server } from 'decentraland-server'
 
 import { Router } from '../common/Router'
+import { addInmutableCacheControlHeader } from '../common/headers'
 import { getBucketURL } from './s3'
 import { S3AssetPack } from './S3AssetPack'
 import { S3Content } from './S3Content'
@@ -26,7 +27,7 @@ export class S3Router extends Router {
 
   private permanentlyRedirectFile(req: Request, res: Response, model: S3Model) {
     const filename = server.extractFromReq(req, 'filename')
-    res.setHeader('Cache-Control', 'public,max-age=31536000,immutable')
+    addInmutableCacheControlHeader(res)
     return res.redirect(this.buildRedirectUrl(model, filename), 301)
   }
 

--- a/src/common/headers.ts
+++ b/src/common/headers.ts
@@ -1,0 +1,7 @@
+import { Response } from 'express'
+
+const DEFAULT_CACHE_CONTROL = 'public,max-age=31536000,immutable'
+
+export function addInmutableCacheControlHeader(res: Response): void {
+  res.setHeader('Cache-Control', DEFAULT_CACHE_CONTROL)
+}


### PR DESCRIPTION
This PR adds the cache header and the permanently moved status code for the remaining modified endpoints that now redirect to S3.
The redirect to the Amazon S3 bucket is being cached, but the file itself manages its cache trough the bucket headers (etag and last modified).