### PR TITLE
feat: Add asset packs owner query parameter

### DIFF
--- a/src/AssetPack/AssetPack.router.ts
+++ b/src/AssetPack/AssetPack.router.ts
@@ -67,7 +67,11 @@ export class AssetPackRouter extends Router {
     /**
      * Get asset packs of an address
      */
-    this.router.get('/ownAssetPacks', withAuthentication, this.getOwnAssetPacks)
+    this.router.get(
+      '/ownAssetPacks',
+      withAuthentication,
+      server.handleRequest(this.getOwnAssetPacks)
+    )
 
     /**
      * Get asset pack

--- a/src/AssetPack/AssetPack.router.ts
+++ b/src/AssetPack/AssetPack.router.ts
@@ -137,7 +137,7 @@ export class AssetPackRouter extends Router {
     if (!ethAddress || ethAddress !== DEFAULT_ETH_ADDRESS) {
       const defaultAssetPacks = await this.logExecutionTime(
         this.retrieveDefaultAssetPacks,
-        'Get default asset packs',
+        `Get the user\'s (${ethAddress}) asset packs`,
         tracer
       )
       assetPacks = [...defaultAssetPacks]

--- a/src/middleware/url.ts
+++ b/src/middleware/url.ts
@@ -3,6 +3,8 @@ import { Request, Response, NextFunction } from 'express'
 /**
  * Lowercase a set of URL params before hitting the handler.
  * It'll lowercase ALL params if the `params` argument is not supplied
+ *
+ * * @param params - The URL parameters to be lowercased
  */
 export function withLowercasedParams(params?: string[]) {
   return (req: Request, _res: Response, next: NextFunction) => {
@@ -20,3 +22,32 @@ export function withLowercasedParams(params?: string[]) {
     next()
   }
 }
+
+/**
+ * Lowercase a set of URL query params before hitting the handler.
+ * The lowercase functionality will only be applied to string query parameters.
+ * It'll lowercase ALL query params if the `params` argument is not supplied.
+ *
+ * @param params - The query parameters to be lowercased
+ */
+export function withLowercaseQueryParams(params?: string[]) {
+  return (req: Request, _res: Response, next: NextFunction) => {
+    if (params) {
+      for (const param of params) {
+        if (param in req.query && isString(req.query[param])) {
+          req.query[param] = (req.query[param] as string).toLowerCase()
+        }
+      }
+    } else {
+      for (const param in Object.keys(req.query)) {
+        if (isString(req.query[param])) {
+          req.query[param] = (req.query[param] as string).toLowerCase()
+        }
+      }
+    }
+    next()
+  }
+}
+
+const isString = (value: unknown) =>
+  typeof value === 'string' || value instanceof String


### PR DESCRIPTION
This PR creates two new endpoints:
- The `/assetPacks/default` endpoint, that returns the default asset packs.
- The `/ownAssetPacks` authenticated endpoint, that returns the user's asset packs.