### PR TITLE
fix: Use /v1/info as the health endpoint

### DIFF
--- a/.ci/index.ts
+++ b/.ci/index.ts
@@ -139,7 +139,7 @@ export = async function main() {
     {
       // @ts-ignore
       healthCheck: {
-        path: '/v1/assetPacks',
+        path: '/v1/info',
         interval: 60,
         timeout: 10,
         unhealthyThreshold: 10,


### PR DESCRIPTION
This PR changes the health endpoint for the info one.