### PR TITLE
fix: Unauthorized owner error in Asset Packs

### DIFF
--- a/src/AssetPack/AssetPack.router.ts
+++ b/src/AssetPack/AssetPack.router.ts
@@ -127,6 +127,7 @@ export class AssetPackRouter extends Router {
     } else if (owner) {
       throw new HTTPError(
         'Unauthorized access to asset packs',
+        { ethAddress },
         STATUS_CODES.unauthorized
       )
     }


### PR DESCRIPTION
This PR fixes an issue where the HTTP error was created with the wrong parameters.