### PR TITLE
feat: Add URN to collection and item

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,4 @@
 
 npm run migrate:docker up || exit 1
 npm run seed || exit 1
-npm run start || exit 1
+node ./dist/src/server.js || exit 1

--- a/migrations/1632517404784_add-urn-to-item-and-collection.ts
+++ b/migrations/1632517404784_add-urn-to-item-and-collection.ts
@@ -8,6 +8,13 @@ const itemTableName = Item.tableName
 
 export const shorthands = undefined
 
+/**
+ * Migrates the DB by adding the URN column to the items and collections tables.
+ * The URN column will be null for Decentraland Collections and for Third Party Collections
+ * it will contain the collection part of the URN.
+ * The URN column will be null for Decentraland Items and for Third Party Collections it will
+ * contain the item part of the URN.
+ */
 export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.addColumn(itemTableName, {
     urn: { type: 'TEXT' },

--- a/migrations/1632517404784_add-urn-to-item-and-collection.ts
+++ b/migrations/1632517404784_add-urn-to-item-and-collection.ts
@@ -1,0 +1,24 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { MigrationBuilder } from 'node-pg-migrate'
+import { Collection } from '../src/Collection'
+import { Item } from '../src/Item'
+
+const collectionTableName = Collection.tableName
+const itemTableName = Item.tableName
+
+export const shorthands = undefined
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumn(itemTableName, {
+    urn: { type: 'TEXT' },
+  })
+
+  pgm.addColumn(collectionTableName, {
+    urn: { type: 'TEXT' },
+  })
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumn(itemTableName, 'urn')
+  pgm.dropColumn(collectionTableName, 'urn')
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -509,6 +509,14 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@dcl/schemas": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-1.8.0.tgz",
+      "integrity": "sha512-hWIL7lfabqBOtHq5hQ/cICegYOUnIQ/4Ds1LvfaFQ/1azDmkbdyRJmkr6JBztdp3emgzojuCyacIJTDBNXA0gw==",
+      "requires": {
+        "ajv": "^7.1.0"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.3.9",
+    "@dcl/schemas": "^1.8.0",
     "@ethersproject/solidity": "^5.0.9",
     "@types/escape-html": "0.0.20",
     "@types/express": "^4.17.11",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint:fix": "tslint -p tsconfig.json --fix",
     "build": "tsc -p tsconfig.json",
     "watch:build": "tsc -p tsconfig.json --watch",
-    "start": "npm run build && node ./dist/src/server.js",
+    "start": "ts-node ./src/server.ts",
     "watch:start": "nodemon src/server.ts",
     "migrate": "ts-node ./migrations/migrate.ts",
     "migrate:docker": "./migrations/node-pg-migrate --database-url-var CONNECTION_STRING --migration-file-language ts --migrations-dir /app/migrations --ignore-pattern '\\..*|.*migrate(.ts)?'",

--- a/src/Asset/Asset.types.ts
+++ b/src/Asset/Asset.types.ts
@@ -1,4 +1,4 @@
-import { metricsSchema } from '../Metrics'
+import { metricsSchema } from '../Metrics/Metrics.schema'
 import { parametersSchema, AssetParameter } from './Parameters'
 import { actionsSchema } from './Actions'
 

--- a/src/Collection/Collection.router.ts
+++ b/src/Collection/Collection.router.ts
@@ -166,7 +166,9 @@ export class CollectionRouter extends Router {
     // Build the URN for the collections
     return consolidatedCollections.map((collection) => ({
       ...collection,
-      urn: collection.urn ?? getDecentralandCollectionURN(collection),
+      urn:
+        collection.urn ??
+        getDecentralandCollectionURN(collection.contract_address),
     }))
   }
 
@@ -219,7 +221,8 @@ export class CollectionRouter extends Router {
     }
 
     fullCollection.urn =
-      fullCollection.urn ?? getDecentralandCollectionURN(fullCollection)
+      fullCollection.urn ??
+      getDecentralandCollectionURN(fullCollection.contract_address)
 
     return fullCollection
   }
@@ -352,9 +355,15 @@ export class CollectionRouter extends Router {
       data
     )
 
-    // Compute the URN for the Decentraland Collection and set it
-    attributes.urn = getDecentralandCollectionURN(attributes)
-    return new Collection(attributes).upsert()
+    // Sets the DCL collection URN to null before writing it to the DB
+    attributes.urn = null
+    const upsertedCollection = await new Collection(attributes).upsert()
+
+    // Return the collection that was updated or inserted with the DCL URN
+    return {
+      ...upsertedCollection,
+      urn: getDecentralandCollectionURN(upsertedCollection.contract_address),
+    }
   }
 
   deleteCollection = async (req: AuthRequest) => {

--- a/src/Collection/Collection.types.ts
+++ b/src/Collection/Collection.types.ts
@@ -1,5 +1,6 @@
 export type CollectionAttributes = {
   id: string // uuid
+  urn: string | null
   name: string
   eth_address: string
   salt: string
@@ -18,6 +19,7 @@ export const collectionSchema = Object.freeze({
   type: 'object',
   properties: {
     id: { type: 'string', format: 'uuid' },
+    urn: { type: ['string'] },
     name: { type: 'string', maxLength: 32 },
     eth_address: { type: 'string' },
     salt: { type: ['string', 'null'] },

--- a/src/Collection/Collection.types.ts
+++ b/src/Collection/Collection.types.ts
@@ -1,5 +1,10 @@
 export type CollectionAttributes = {
   id: string // uuid
+  /**
+   * The urn field holds the collection part of the URN in third party collections.
+   * All Decentraland collections will contain this column as null but it will be generated and returned
+   * whenever a Decentraland collection is requested.
+   */
   urn: string | null
   name: string
   eth_address: string

--- a/src/Collection/utils.ts
+++ b/src/Collection/utils.ts
@@ -1,10 +1,7 @@
 import { getCurrentNetworkURNProtocol } from '../ethereum/utils'
-import { CollectionAttributes } from './Collection.types'
 
 export function getDecentralandCollectionURN(
-  collection: CollectionAttributes
+  collectionAddress: string
 ): string {
-  return `urn:decentraland:${getCurrentNetworkURNProtocol()}:collections-v2:${
-    collection.contract_address
-  }}`
+  return `urn:decentraland:${getCurrentNetworkURNProtocol()}:collections-v2:${collectionAddress}`
 }

--- a/src/Collection/utils.ts
+++ b/src/Collection/utils.ts
@@ -1,0 +1,10 @@
+import { getCurrentNetworkURNProtocol } from '../ethereum/utils'
+import { CollectionAttributes } from './Collection.types'
+
+export function getDecentralandCollectionURN(
+  collection: CollectionAttributes
+): string {
+  return `urn:decentraland:${getCurrentNetworkURNProtocol()}:collections-v2:${
+    collection.contract_address
+  }}`
+}

--- a/src/Item/Item.router.ts
+++ b/src/Item/Item.router.ts
@@ -24,6 +24,7 @@ import { hasAccess as hasCollectionAccess } from '../Collection/access'
 import { isCommitteeMember } from '../Committee'
 import { itemSchema } from './Item.types'
 import { hasAccess } from './access'
+import { getDecentralandItemURN } from './utils'
 
 const validator = getValidator()
 
@@ -268,7 +269,12 @@ export class ItemRouter extends Router {
       )
     }
 
-    return Bridge.consolidateItems(dbItems, remoteItems, catalystItems)
+    return (
+      await Bridge.consolidateItems(dbItems, remoteItems, catalystItems)
+    ).map(
+      (item) =>
+        (item.urn = item.urn ?? getDecentralandItemURN(item, fullCollection))
+    )
   }
 
   async upsertItem(req: AuthRequest) {

--- a/src/Item/Item.schema.ts
+++ b/src/Item/Item.schema.ts
@@ -1,0 +1,48 @@
+import { metricsSchema } from '../Metrics/Metrics.schema'
+import { ItemRarity, ItemType } from './Item.types'
+import { wearableSchema } from './wearable/types'
+
+export const itemSchema = Object.freeze({
+  type: 'object',
+  properties: {
+    id: { type: 'string', format: 'uuid' },
+    urn: { type: ['string', 'null'] },
+    name: { type: 'string', maxLength: 32 },
+    description: { type: ['string', 'null'], maxLength: 64 },
+    thumbnail: { type: 'string' },
+    eth_address: { type: 'string' },
+    collection_id: { type: ['string', 'null'], format: 'uuid' },
+    blockchain_item_id: { type: ['string', 'null'] },
+    price: { type: ['string', 'null'] },
+    beneficiary: { type: ['string', 'null'] },
+    rarity: {
+      type: ['string', 'null'],
+      enum: [...Object.values(ItemRarity), null],
+    },
+    total_supply: { type: 'number', minimum: 0 },
+    is_published: { type: 'boolean' },
+    is_approved: { type: 'boolean' },
+    type: { enum: Object.values(ItemType) },
+    data: { type: 'object', oneOf: [wearableSchema] },
+    metrics: metricsSchema,
+    contents: {
+      type: 'object',
+      additionalProperties: true,
+    },
+    created_at: { type: 'string' },
+    updated_at: { type: 'string' },
+  },
+  additionalProperties: false,
+  required: [
+    'id',
+    'name',
+    'description',
+    'eth_address',
+    'data',
+    'type',
+    'metrics',
+    'contents',
+    'created_at',
+    'updated_at',
+  ],
+})

--- a/src/Item/Item.types.ts
+++ b/src/Item/Item.types.ts
@@ -1,5 +1,5 @@
-import { MetricsAttributes, metricsSchema } from '../Metrics'
-import { WearableData, wearableSchema } from './wearable/types'
+import { MetricsAttributes } from '../Metrics'
+import { WearableData } from './wearable/types'
 
 export enum ItemType {
   WEARABLE = 'wearable',
@@ -38,48 +38,3 @@ export type ItemAttributes = {
   created_at: Date
   updated_at: Date
 }
-
-export const itemSchema = Object.freeze({
-  type: 'object',
-  properties: {
-    id: { type: 'string', format: 'uuid' },
-    urn: { type: 'string' },
-    name: { type: 'string', maxLength: 32 },
-    description: { type: ['string', 'null'], maxLength: 64 },
-    thumbnail: { type: 'string' },
-    eth_address: { type: 'string' },
-    collection_id: { type: ['string', 'null'], format: 'uuid' },
-    blockchain_item_id: { type: ['string', 'null'] },
-    price: { type: ['string', 'null'] },
-    beneficiary: { type: ['string', 'null'] },
-    rarity: {
-      type: ['string', 'null'],
-      enum: [...Object.values(ItemRarity), null],
-    },
-    total_supply: { type: 'number', minimum: 0 },
-    is_published: { type: 'boolean' },
-    is_approved: { type: 'boolean' },
-    type: { enum: Object.values(ItemType) },
-    data: { type: 'object', oneOf: [wearableSchema] },
-    metrics: metricsSchema,
-    contents: {
-      type: 'object',
-      additionalProperties: true,
-    },
-    created_at: { type: 'string' },
-    updated_at: { type: 'string' },
-  },
-  additionalProperties: false,
-  required: [
-    'id',
-    'name',
-    'description',
-    'eth_address',
-    'data',
-    'type',
-    'metrics',
-    'contents',
-    'created_at',
-    'updated_at',
-  ],
-})

--- a/src/Item/Item.types.ts
+++ b/src/Item/Item.types.ts
@@ -17,6 +17,7 @@ export enum ItemRarity {
 
 export type ItemAttributes = {
   id: string // uuid
+  urn: string | null
   name: string
   description: string
   thumbnail: string
@@ -42,6 +43,7 @@ export const itemSchema = Object.freeze({
   type: 'object',
   properties: {
     id: { type: 'string', format: 'uuid' },
+    urn: { type: 'string' },
     name: { type: 'string', maxLength: 32 },
     description: { type: ['string', 'null'], maxLength: 64 },
     thumbnail: { type: 'string' },

--- a/src/Item/Item.types.ts
+++ b/src/Item/Item.types.ts
@@ -17,6 +17,11 @@ export enum ItemRarity {
 
 export type ItemAttributes = {
   id: string // uuid
+  /**
+   * The urn field holds the item part of the URN in third party items.
+   * All Decentraland items will contain this column as null but it will be generated and returned
+   * whenever a Decentraland item that is published is requested.
+   */
   urn: string | null
   name: string
   description: string

--- a/src/Item/utils.ts
+++ b/src/Item/utils.ts
@@ -1,0 +1,10 @@
+import { CollectionAttributes } from '../Collection/Collection.types'
+import { getDecentralandCollectionURN } from '../Collection/utils'
+import { ItemAttributes } from './Item.types'
+
+export function getDecentralandItemURN(
+  item: ItemAttributes,
+  collection: CollectionAttributes
+): string {
+  return `${getDecentralandCollectionURN(collection)}:${item.id}`
+}

--- a/src/Item/utils.ts
+++ b/src/Item/utils.ts
@@ -1,10 +1,11 @@
-import { CollectionAttributes } from '../Collection/Collection.types'
 import { getDecentralandCollectionURN } from '../Collection/utils'
 import { ItemAttributes } from './Item.types'
 
 export function getDecentralandItemURN(
   item: ItemAttributes,
-  collection: CollectionAttributes
+  collectionAddress: string
 ): string {
-  return `${getDecentralandCollectionURN(collection)}:${item.id}`
+  return `${getDecentralandCollectionURN(collectionAddress)}:${
+    item.blockchain_item_id
+  }`
 }

--- a/src/Metrics/Metrics.schema.ts
+++ b/src/Metrics/Metrics.schema.ts
@@ -1,0 +1,20 @@
+export const metricsSchema = Object.freeze({
+  type: 'object',
+  properties: {
+    meshes: { type: 'number', minimum: 0 },
+    bodies: { type: 'number', minimum: 0 },
+    materials: { type: 'number', minimum: 0 },
+    textures: { type: 'number', minimum: 0 },
+    triangles: { type: 'number', minimum: 0 },
+    entities: { type: 'number', minimum: 0 },
+  },
+  additionalProperties: false,
+  required: [
+    'meshes',
+    'bodies',
+    'materials',
+    'textures',
+    'triangles',
+    'entities',
+  ],
+})

--- a/src/Metrics/Metrics.types.ts
+++ b/src/Metrics/Metrics.types.ts
@@ -6,24 +6,3 @@ export type MetricsAttributes = {
   triangles: number
   entities: number
 }
-
-export const metricsSchema = Object.freeze({
-  type: 'object',
-  properties: {
-    meshes: { type: 'number', minimum: 0 },
-    bodies: { type: 'number', minimum: 0 },
-    materials: { type: 'number', minimum: 0 },
-    textures: { type: 'number', minimum: 0 },
-    triangles: { type: 'number', minimum: 0 },
-    entities: { type: 'number', minimum: 0 },
-  },
-  additionalProperties: false,
-  required: [
-    'meshes',
-    'bodies',
-    'materials',
-    'textures',
-    'triangles',
-    'entities',
-  ],
-})

--- a/src/ethereum/api/Bridge.ts
+++ b/src/ethereum/api/Bridge.ts
@@ -1,11 +1,11 @@
 import { CollectionAttributes, Collection } from '../../Collection'
 import { ItemAttributes, Item, ItemRarity } from '../../Item'
 import { MetricsAttributes } from '../../Metrics'
+import { fromUnixTimestamp } from '../../utils/parse'
+import { WearableCategory, WearableData } from '../../Item/wearable/types'
 import { ItemFragment, CollectionFragment } from './fragments'
 import { collectionAPI } from './collection'
 import { Wearable } from './peer'
-import { fromUnixTimestamp } from '../../utils/parse'
-import { WearableCategory, WearableData } from '../../Item/wearable/types'
 
 export class Bridge {
   static async consolidateCollections(
@@ -147,6 +147,7 @@ export class Bridge {
     let contents: Record<string, string>
     let metrics: MetricsAttributes
     let in_catalyst: boolean
+    let urn: string | null = null
 
     if (catalystItem) {
       data = catalystItem.data
@@ -158,6 +159,12 @@ export class Bridge {
       contents = dbItem.contents
       metrics = dbItem.metrics
       in_catalyst = false
+    }
+
+    if (catalystItem) {
+      urn = catalystItem.id
+    } else if (remoteItem && remoteItem.urn) {
+      urn = remoteItem.urn
     }
 
     if (wearable) {
@@ -182,6 +189,7 @@ export class Bridge {
     return {
       ...dbItem,
       name,
+      urn,
       description,
       rarity,
       price: remoteItem.price,

--- a/src/ethereum/api/collection.ts
+++ b/src/ethereum/api/collection.ts
@@ -17,7 +17,6 @@ import {
   RarityFragment,
 } from './fragments'
 import { createClient } from './graphClient'
-import { Bridge } from './Bridge'
 
 const MAX_RESULTS = 1000
 
@@ -151,12 +150,6 @@ export const COLLECTIONS_URL = env.get('COLLECTIONS_GRAPH_URL', '')
 const graphClient = createClient(COLLECTIONS_URL)
 
 export class CollectionAPI {
-  bridge: Bridge
-
-  constructor() {
-    this.bridge = new Bridge()
-  }
-
   fetchCollection = async (contractAddress: string) => {
     const {
       data: { collections = [] },

--- a/src/ethereum/utils.ts
+++ b/src/ethereum/utils.ts
@@ -1,0 +1,22 @@
+import { env } from 'decentraland-commons'
+import { ChainId, getURNProtocol } from '@dcl/schemas'
+import { Network } from './types'
+
+const network = env.get('ETHEREUM_NETWORK') as Network
+
+function getChainIdFromNetwork(network: Network): ChainId {
+  switch (network) {
+    case Network.MAINNET:
+      return ChainId.ETHEREUM_MAINNET
+    case Network.ROPSTEN:
+      return ChainId.ETHEREUM_ROPSTEN
+    default:
+      throw new Error(
+        `The network ${network} doesn't have a chain id to map to`
+      )
+  }
+}
+
+export function getCurrentNetworkURNProtocol(): string {
+  return getURNProtocol(getChainIdFromNetwork(network))
+}


### PR DESCRIPTION
This PR does the following:
- Changes the entrypoint to start the server without building it again.
- Adds the URN column to the collection and the items.
- Adds the logic to generate the URNs at the time of retrieving the collections and the items.
- Moves the item schema to another file to fix a circular dependency.