### PR TITLE
fix: Add async and default error handler

### DIFF
--- a/src/AssetPack/AssetPack.router.ts
+++ b/src/AssetPack/AssetPack.router.ts
@@ -18,6 +18,8 @@ import {
   AuthRequest,
 } from '../middleware/authentication'
 import { S3AssetPack, getFileUploader, ACL } from '../S3'
+import { ExpressApp } from '../common/ExpressApp'
+import { asyncHandler } from '../common/asyncHandler'
 import { Ownable } from '../Ownable'
 import { Asset } from '../Asset'
 import { AssetPack } from './AssetPack.model'
@@ -27,7 +29,6 @@ import {
   assetPackSchema,
 } from './AssetPack.types'
 import { getDefaultEthAddress } from './utils'
-import { ExpressApp } from '../common/ExpressApp'
 
 const BLACKLISTED_PROPERTIES = ['is_deleted']
 const THUMBNAIL_FILE_NAME = 'thumbnail'
@@ -59,7 +60,7 @@ export class AssetPackRouter extends Router {
       '/assetPacks',
       withPermissiveAuthentication,
       withLowercaseQueryParams(['owner']),
-      this.getAssetPacks
+      asyncHandler(this.getAssetPacks)
     )
 
     /**

--- a/src/Manifest/Manifest.router.ts
+++ b/src/Manifest/Manifest.router.ts
@@ -13,7 +13,6 @@ import {
 } from '../middleware'
 import { Ownable } from '../Ownable'
 import { Project } from '../Project'
-import { ManifestAttributes, manifestSchema } from './Manifest.types'
 import {
   S3Project,
   MANIFEST_FILENAME,
@@ -21,8 +20,10 @@ import {
   ACL,
   getBucketURL,
 } from '../S3'
-import { collectStatistics } from './utils'
 import { SearchableProject } from '../Project/SearchableProject'
+import { asyncHandler } from '../common/asyncHandler'
+import { ManifestAttributes, manifestSchema } from './Manifest.types'
+import { collectStatistics } from './utils'
 
 const validator = getValidator()
 
@@ -42,7 +43,7 @@ export class ManifestRouter extends Router {
       withAuthentication,
       withProjectExists,
       withProjectAuthorization,
-      this.getProjectManifest
+      asyncHandler(this.getProjectManifest)
     )
 
     /**

--- a/src/Manifest/Manifest.router.ts
+++ b/src/Manifest/Manifest.router.ts
@@ -21,7 +21,6 @@ import {
   getBucketURL,
 } from '../S3'
 import { SearchableProject } from '../Project/SearchableProject'
-import { asyncHandler } from '../common/asyncHandler'
 import { ManifestAttributes, manifestSchema } from './Manifest.types'
 import { collectStatistics } from './utils'
 
@@ -43,7 +42,7 @@ export class ManifestRouter extends Router {
       withAuthentication,
       withProjectExists,
       withProjectAuthorization,
-      asyncHandler(this.getProjectManifest)
+      this.getProjectManifest
     )
 
     /**

--- a/src/Share/Share.router.ts
+++ b/src/Share/Share.router.ts
@@ -9,6 +9,7 @@ import { withSocialUserAgentDetector, SocialRequest } from '../middleware/share'
 import { Params, ElementType } from './Share.types'
 import { Pool, PoolAttributes } from '../Pool'
 import { ProjectAttributes } from '../Project'
+import { asyncHandler } from '../common/asyncHandler'
 import template from './template'
 
 const BUILDER_URL = env.get('BUILDER_URL', '')
@@ -23,7 +24,7 @@ export class ShareRouter extends Router {
     this.router.get(
       '/share/:type(scene|pool)/:id',
       withSocialUserAgentDetector,
-      this.redirectToBuilder
+      asyncHandler(this.redirectToBuilder)
     )
   }
 

--- a/src/common/ErrorHandling.spec.ts
+++ b/src/common/ErrorHandling.spec.ts
@@ -1,0 +1,107 @@
+import supertest from 'supertest'
+import express from 'express'
+import { buildURL } from '../../spec/utils'
+import { app } from '../server'
+import { HTTPError } from './HTTPError'
+import { asyncHandler } from './asyncHandler'
+
+const errorMessage = 'anErrorMessage'
+const errorStatusCode = 400
+const errorData = { id: 'anId' }
+
+const handlerWithHttpError = () => {
+  throw new HTTPError(errorMessage, errorData, errorStatusCode)
+}
+const handlerWithCommonError = () => {
+  throw new HTTPError(errorMessage, errorData, errorStatusCode)
+}
+const handlerWithSentHeadersAndCommonError = (
+  _: express.Request,
+  res: express.Response
+) => {
+  res.sendStatus(401)
+  throw new HTTPError(errorMessage, errorData, errorStatusCode)
+}
+
+const asyncHandlerWithHttpError = async () => handlerWithHttpError()
+const asyncHandlerWithError = async () => handlerWithCommonError()
+
+app.getRouter().get('/syncHttpError', handlerWithHttpError)
+app.getRouter().get('/asyncHttpError', asyncHandler(asyncHandlerWithHttpError))
+app.getRouter().get('/syncError', handlerWithCommonError)
+app.getRouter().get('/asyncError', asyncHandler(asyncHandlerWithError))
+app
+  .getRouter()
+  .get('/syncErrorWithSentHeaders', handlerWithSentHeadersAndCommonError)
+
+const server = supertest(app.getApp())
+
+describe('when handling an error when the headers have already been sent', () => {
+  it('should respond with the set status code and the default express error handler', () => {
+    return server
+      .get(buildURL('/syncErrorWithSentHeaders'))
+      .expect(401)
+      .expect('Content-Type', 'text/plain; charset=utf-8')
+      .then(() => undefined)
+  })
+})
+
+describe('when handling async http errors', () => {
+  it('should respond with the thrown error status code, the message and the data', () => {
+    return server
+      .get(buildURL('/asyncHttpError'))
+      .expect(errorStatusCode)
+      .then((response: any) => {
+        expect(response.body).toEqual({
+          error: errorMessage,
+          data: errorData,
+          ok: false,
+        })
+      })
+  })
+})
+
+describe('when handling async errors', () => {
+  it('should respond with the a 500 an the error message', () => {
+    return server
+      .get(buildURL('/asyncError'))
+      .expect(errorStatusCode)
+      .then((response: any) => {
+        expect(response.body).toEqual({
+          error: errorMessage,
+          data: errorData,
+          ok: false,
+        })
+      })
+  })
+})
+
+describe('when handling sync http errors', () => {
+  it('should respond with the thrown error status code, the message and the data', () => {
+    return server
+      .get(buildURL('/syncError'))
+      .expect(errorStatusCode)
+      .then((response: any) => {
+        expect(response.body).toEqual({
+          error: errorMessage,
+          data: errorData,
+          ok: false,
+        })
+      })
+  })
+})
+
+describe('when handling sync errors', () => {
+  it('should respond with the a 500 an the error message', () => {
+    return server
+      .get(buildURL('/syncError'))
+      .expect(errorStatusCode)
+      .then((response: any) => {
+        expect(response.body).toEqual({
+          error: errorMessage,
+          data: errorData,
+          ok: false,
+        })
+      })
+  })
+})

--- a/src/common/ErrorHandling.spec.ts
+++ b/src/common/ErrorHandling.spec.ts
@@ -13,14 +13,14 @@ const handlerWithHttpError = () => {
   throw new HTTPError(errorMessage, errorData, errorStatusCode)
 }
 const handlerWithCommonError = () => {
-  throw new HTTPError(errorMessage, errorData, errorStatusCode)
+  throw new Error(errorMessage)
 }
 const handlerWithSentHeadersAndCommonError = (
   _: express.Request,
   res: express.Response
 ) => {
   res.sendStatus(401)
-  throw new HTTPError(errorMessage, errorData, errorStatusCode)
+  throw new Error(errorMessage)
 }
 
 const asyncHandlerWithHttpError = async () => handlerWithHttpError()
@@ -65,11 +65,11 @@ describe('when handling async errors', () => {
   it('should respond with the a 500 an the error message', () => {
     return server
       .get(buildURL('/asyncError'))
-      .expect(errorStatusCode)
+      .expect(500)
       .then((response: any) => {
         expect(response.body).toEqual({
           error: errorMessage,
-          data: errorData,
+          data: {},
           ok: false,
         })
       })
@@ -77,14 +77,14 @@ describe('when handling async errors', () => {
 })
 
 describe('when handling sync http errors', () => {
-  it('should respond with the thrown error status code, the message and the data', () => {
+  it('should respond with the a 500 an the error message', () => {
     return server
       .get(buildURL('/syncError'))
-      .expect(errorStatusCode)
+      .expect(500)
       .then((response: any) => {
         expect(response.body).toEqual({
           error: errorMessage,
-          data: errorData,
+          data: {},
           ok: false,
         })
       })
@@ -95,11 +95,11 @@ describe('when handling sync errors', () => {
   it('should respond with the a 500 an the error message', () => {
     return server
       .get(buildURL('/syncError'))
-      .expect(errorStatusCode)
+      .expect(500)
       .then((response: any) => {
         expect(response.body).toEqual({
           error: errorMessage,
-          data: errorData,
+          data: {},
           ok: false,
         })
       })

--- a/src/common/ErrorHandling.spec.ts
+++ b/src/common/ErrorHandling.spec.ts
@@ -79,12 +79,12 @@ describe('when handling async errors', () => {
 describe('when handling sync http errors', () => {
   it('should respond with the a 500 an the error message', () => {
     return server
-      .get(buildURL('/syncError'))
-      .expect(500)
+      .get(buildURL('/syncHttpError'))
+      .expect(errorStatusCode)
       .then((response: any) => {
         expect(response.body).toEqual({
           error: errorMessage,
-          data: {},
+          data: errorData,
           ok: false,
         })
       })

--- a/src/common/ExpressApp.ts
+++ b/src/common/ExpressApp.ts
@@ -118,7 +118,7 @@ export class ExpressApp {
     return this
   }
 
-  use(...handers: express.RequestHandler[]) {
+  use(...handers: express.RequestHandler[] | express.ErrorRequestHandler[]) {
     this.app.use(...handers)
     return this
   }

--- a/src/common/asyncHandler.ts
+++ b/src/common/asyncHandler.ts
@@ -1,0 +1,9 @@
+import express from 'express'
+
+export const asyncHandler = (fn: any) => (
+  req?: express.Request,
+  res?: express.Response,
+  next?: express.NextFunction
+): Promise<unknown> => {
+  return Promise.resolve(fn(req, res, next)).catch(next)
+}

--- a/src/common/errorHandler.ts
+++ b/src/common/errorHandler.ts
@@ -1,0 +1,23 @@
+import { sendError } from 'decentraland-server/dist/server'
+import express from 'express'
+import { HTTPError } from './HTTPError'
+
+export function errorHandler(
+  error: Error,
+  _: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) {
+  // If for some reasons, the headers have already been sent, handle
+  // the error with the default error handler
+  if (res.headersSent) {
+    return next(error)
+  }
+
+  const data = (error as HTTPError).data ?? {}
+  const message = error.message
+  const statusCode = (error as HTTPError).statusCode ?? 500
+
+  res.status(statusCode)
+  res.json(sendError(data, message))
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -38,7 +38,6 @@ app
   .useJSON()
   .useVersion(API_VERSION)
   .useMetrics()
-  .use(errorHandler)
 
 // Mount routers
 new AppRouter(app).mount()
@@ -59,6 +58,8 @@ new DeploymentRouter(app).mount()
 new S3Router(app).mount()
 new ShareRouter(app).mount()
 new AnalyticsRouter(app).mount()
+
+app.use(errorHandler)
 
 /* Start the server only if run directly */
 if (require.main === module) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,6 +22,7 @@ import { db } from './database'
 import { ExpressApp } from './common/ExpressApp'
 import { withLogger } from './middleware'
 import { ProjectByCoordRouter } from './Project'
+import { errorHandler } from './common/errorHandler'
 
 const SERVER_PORT = env.get('SERVER_PORT', '5000')
 const API_VERSION = env.get('API_VERSION', 'v1')
@@ -37,6 +38,7 @@ app
   .useJSON()
   .useVersion(API_VERSION)
   .useMetrics()
+  .use(errorHandler)
 
 // Mount routers
 new AppRouter(app).mount()


### PR DESCRIPTION
This PR adds an async handler wrapper that catches errors in async handlers and calls the next function so the errors can be  handled by the express error handlers. A simple error handler is added too, replicating the error handler in the decentraland server code.