### PR TITLE
fix: Github actions failing to execute

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -30,7 +30,7 @@ jobs:
           ANALYTICS_CONNECTION_STRING: ANALYTICS_CONNECTION_STRING
           PEER_URL: https://peer.decentraland.zone
           ETHEREUM_NETWORK: ropsten
-          TPW_MANAGER_ADDRESSES: 0xc6d2000a7a1ddca92941f4e2b41360fe4ee2abd9
+          TPW_MANAGER_ADDRESSES: '0xc6d2000a7a1ddca92941f4e2b41360fe4ee2abd9'
       - name: Report Coverage
         uses: coverallsapp/github-action@master
         with:


### PR DESCRIPTION
Github actions started failing to execute after the introduction of the TPW_MANAGER_ADDRESS.