### PR TITLE
chore: Remove the upload of asset packs on the CI

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 
 npm run migrate:docker up || exit 1
-npm run seed || exit 1
 node --inspect="0.0.0.0:9229" ./dist/src/server.js || exit 1


### PR DESCRIPTION
This PR removes the upload of assets packs that was done in the CI process. This process was no necessary, as the AssetPacks don't usually change. We're removing it in favor of doing this process manually (or adding it again to the CI) whenever the asset packs change.