### PR TITLE
feat: Reset unsynced items is parellized + safe exit

### DIFF
--- a/scripts/resetUnsyncedItems.ts
+++ b/scripts/resetUnsyncedItems.ts
@@ -11,7 +11,7 @@ import { ACL, S3Content } from '../src/S3'
 
 const RESET_IN_PARALLEL = 5
 const FAILURE_RETRIES = 3
-//const ITEM_ID_SET = new Set([])
+// const ITEM_ID_SET = new Set<string>([])
 
 async function run() {
   console.log('DB: Connecting...')
@@ -29,7 +29,6 @@ async function run() {
       remoteItems,
       catalystItems
     )
-    //.then((items) => items.filter((item) => ITEM_ID_SET.has(item.id)))
 
     const catalystItemsByUrn = catalystItems.reduce((acc, item) => {
       acc[item.id] = item
@@ -40,6 +39,7 @@ async function run() {
       (item) =>
         item.urn &&
         catalystItemsByUrn[item.urn] &&
+        // ITEM_ID_SET.has(item.id)
         isDifferent(item, catalystItemsByUrn[item.urn])
     )
 

--- a/scripts/resetUnsyncedItems.ts
+++ b/scripts/resetUnsyncedItems.ts
@@ -193,12 +193,12 @@ async function resetItems(
   const failed: FullItem[] = []
   const batches: FullItem[][] = []
 
-  items.forEach((item, index) => {
+  for (const [index, item] of items.entries()) {
     if (index % parallel === 0) {
       batches.push([])
     }
     batches[batches.length - 1].push(item)
-  })
+  }
 
   for (const batch of batches) {
     console.log(`Reseting batch ${batchCount++}/${batches.length}`)

--- a/scripts/resetUnsyncedItems.ts
+++ b/scripts/resetUnsyncedItems.ts
@@ -175,14 +175,20 @@ async function resetItems(
   retries: number = FAILURE_RETRIES,
   current: number = 1
 ): Promise<FullItem[]> {
+  let sigintReceived = false
+
+  process.on('SIGINT', () => {
+    sigintReceived = true
+  })
+
   if (items.length === 0 || current > retries) {
     return items
   }
 
   let batchCount = 1
   let itemCount = 1
-  const failed: FullItem[] = []
 
+  const failed: FullItem[] = []
   const batches: FullItem[][] = []
 
   items.forEach((item, index) => {
@@ -207,6 +213,11 @@ async function resetItems(
         }
       })
     )
+
+    if (sigintReceived) {
+      console.log('Exiting Safely...')
+      process.exit(1)
+    }
 
     batchCount++
   }

--- a/scripts/resetUnsyncedItems.ts
+++ b/scripts/resetUnsyncedItems.ts
@@ -11,7 +11,7 @@ import { ACL, S3Content } from '../src/S3'
 
 const RESET_IN_PARALLEL = 5
 const FAILURE_RETRIES = 3
-// const ITEM_ID_SET = new Set<string>([])
+const ITEM_ID_SET = new Set<string>([])
 
 async function run() {
   console.log('DB: Connecting...')
@@ -39,8 +39,8 @@ async function run() {
       (item) =>
         item.urn &&
         catalystItemsByUrn[item.urn] &&
-        // ITEM_ID_SET.has(item.id)
-        isDifferent(item, catalystItemsByUrn[item.urn])
+        (ITEM_ID_SET.has(item.id) ||
+          isDifferent(item, catalystItemsByUrn[item.urn]))
     )
 
     if (differentItems.length === 0) {


### PR DESCRIPTION
Can now set the amount of items to be reset at the same time.
When items are reseting, ctrl-c will wait until the current batch of items finishes to exit.
Reduced amount of unimportant log messages.
Added set of items ids variable to always reset.