### PR TITLE
chore: Extract and refactor collection service exceptions

### DIFF
--- a/src/Collection/Collection.exceptions.ts
+++ b/src/Collection/Collection.exceptions.ts
@@ -1,0 +1,48 @@
+export enum CollectionType {
+  THIRD_PARTY,
+  DCL,
+}
+
+export enum CollectionAction {
+  DELETE = 'deleted',
+  UPSERT = 'updated or inserted',
+  UPDATE = 'updated',
+}
+
+export class CollectionLockedException extends Error {
+  constructor(public id: string, action: CollectionAction) {
+    super(`The collection is locked. It can't be ${action}.`)
+  }
+}
+
+export class CollectionAlreadyPublishedException extends Error {
+  constructor(
+    public id: string,
+    type: CollectionType,
+    action: CollectionAction
+  ) {
+    super(
+      type === CollectionType.DCL
+        ? `The collection is published. It can't be ${action}.`
+        : `The third party collection already has published items. It can't be ${action}.`
+    )
+  }
+}
+
+export class WrongCollectionException extends Error {
+  constructor(m: string, public data: Record<string, any>) {
+    super(m)
+  }
+}
+
+export class UnauthorizedCollectionEditException extends Error {
+  constructor(public id: string, public eth_address: string) {
+    super('Unauthorized to upsert collection')
+  }
+}
+
+export class NonExistentCollectionException extends Error {
+  constructor(public id: string) {
+    super("The collection doesn't exist.")
+  }
+}

--- a/src/Collection/Collection.router.spec.ts
+++ b/src/Collection/Collection.router.spec.ts
@@ -312,7 +312,7 @@ describe('Collection router', () => {
                 data: {
                   id: dbTPCollection.id,
                 },
-                error: "The collection is locked. It can't be saved.",
+                error: "The collection is locked. It can't be updated.",
               })
             })
         })
@@ -593,7 +593,7 @@ describe('Collection router', () => {
                 data: {
                   id: dbCollection.id,
                 },
-                error: "The collection is published. It can't be saved.",
+                error: "The collection is published. It can't be updated.",
               })
             })
         })
@@ -637,7 +637,7 @@ describe('Collection router', () => {
                 data: {
                   id: dbCollection.id,
                 },
-                error: "The collection is locked. It can't be saved.",
+                error: "The collection is locked. It can't be updated.",
               })
             })
         })

--- a/src/Collection/Collection.router.ts
+++ b/src/Collection/Collection.router.ts
@@ -19,18 +19,18 @@ import { isCommitteeMember } from '../Committee'
 import { RequestParameters } from '../RequestParameters'
 import { sendDataToWarehouse } from '../warehouse'
 import { Collection } from './Collection.model'
-import {
-  CollectionService,
-  CollectionLockedException,
-  CollectionAlreadyPublishedException,
-  WrongCollectionException,
-  UnauthorizedCollectionEditException,
-} from './Collection.service'
+import { CollectionService } from './Collection.service'
 import { CollectionAttributes, FullCollection } from './Collection.types'
 import { upsertCollectionSchema, saveTOSSchema } from './Collection.schema'
 import { hasAccess } from './access'
 import { toFullCollection, isTPCollection } from './utils'
 import { OwnableModel } from '../Ownable/Ownable.types'
+import {
+  CollectionAlreadyPublishedException,
+  CollectionLockedException,
+  UnauthorizedCollectionEditException,
+  WrongCollectionException,
+} from './Collection.exceptions'
 
 const validator = getValidator()
 


### PR DESCRIPTION
This PR extracts the collection's service exceptions into a new file.
Instead of receiving an action in a string format, the exceptions now receive an enum.