### PR TITLE
fix: allow null urns for DCL collections

### DIFF
--- a/src/Collection/Collection.router.spec.ts
+++ b/src/Collection/Collection.router.spec.ts
@@ -706,6 +706,40 @@ describe('Collection router', () => {
               })
             })
         })
+
+        describe('and the urn supplied is null', () => {
+          beforeEach(() => {
+            collectionToUpsert = {
+              ...toFullCollection(dbCollection),
+              urn: null,
+            }
+          })
+
+          it('should upsert the collection and respond with a 200 and the upserted collection', () => {
+            return server
+              .put(buildURL(url))
+              .set(createAuthHeaders('put', url))
+              .send({
+                collection: collectionToUpsert,
+                data: collectionDataMock,
+              })
+              .expect(200)
+              .then((response: any) => {
+                expect(response.body).toEqual({
+                  ok: true,
+                  data: toFullCollection(newCollectionAttributes),
+                })
+
+                expect(newCollectionAttributes).toEqual({
+                  ...convertCollectionDatesToISO(
+                    toDBCollection(collectionToUpsert)
+                  ),
+                  contract_address: expect.any(String),
+                  salt: expect.any(String),
+                })
+              })
+          })
+        })
       })
     })
   })

--- a/src/Collection/Collection.router.ts
+++ b/src/Collection/Collection.router.ts
@@ -29,7 +29,7 @@ import {
 import { CollectionAttributes, FullCollection } from './Collection.types'
 import { upsertCollectionSchema, saveTOSSchema } from './Collection.schema'
 import { hasAccess } from './access'
-import { toFullCollection, isTPCollectionURN } from './utils'
+import { toFullCollection, hasTPCollectionURN } from './utils'
 import { OwnableModel } from '../Ownable/Ownable.types'
 
 const validator = getValidator()
@@ -380,7 +380,7 @@ export class CollectionRouter extends Router {
     let upsertedCollection: CollectionAttributes
 
     try {
-      if (collectionJSON.urn && isTPCollectionURN(collectionJSON.urn)) {
+      if (hasTPCollectionURN(collectionJSON)) {
         upsertedCollection = await this.service.upsertTPWCollection(
           id,
           eth_address,

--- a/src/Collection/Collection.router.ts
+++ b/src/Collection/Collection.router.ts
@@ -380,7 +380,7 @@ export class CollectionRouter extends Router {
     let upsertedCollection: CollectionAttributes
 
     try {
-      if (isTPCollectionURN(collectionJSON.urn)) {
+      if (collectionJSON.urn && isTPCollectionURN(collectionJSON.urn)) {
         upsertedCollection = await this.service.upsertTPWCollection(
           id,
           eth_address,

--- a/src/Collection/Collection.schema.ts
+++ b/src/Collection/Collection.schema.ts
@@ -4,7 +4,7 @@ export const collectionSchema = Object.freeze({
   type: 'object',
   properties: {
     id: { type: 'string', format: 'uuid' },
-    urn: { type: ['string'], pattern: matchers.urn },
+    urn: { type: ['string', 'null'], pattern: matchers.urn },
     name: { type: 'string', maxLength: 32 },
     eth_address: { type: 'string' },
     salt: { type: ['string', 'null'] },

--- a/src/Collection/Collection.service.ts
+++ b/src/Collection/Collection.service.ts
@@ -145,6 +145,13 @@ export class CollectionService {
     eth_address: string,
     collectionJSON: FullCollection
   ) {
+    if (collectionJSON.urn === null) {
+      throw new WrongCollectionException(
+        'Invalid empty URN for third party collection',
+        { id, eth_address, urn: collectionJSON.urn }
+      )
+    }
+
     if (!(await this.isTPWManager(collectionJSON.urn, eth_address))) {
       throw new UnauthorizedCollectionEditException(id, eth_address)
     }

--- a/src/Collection/Collection.types.ts
+++ b/src/Collection/Collection.types.ts
@@ -26,5 +26,5 @@ export type FullCollection = Omit<
   CollectionAttributes,
   'urn_suffix' | 'third_party_id'
 > & {
-  urn: string
+  urn: string | null
 }

--- a/src/Collection/utils.ts
+++ b/src/Collection/utils.ts
@@ -51,7 +51,7 @@ export function toFullCollection(
 export function toDBCollection(
   collection: FullCollection
 ): CollectionAttributes {
-  const isTPW = collection.urn && isTPCollectionURN(collection.urn)
+  const isTPW = hasTPCollectionURN(collection)
   const decodedURN = isTPW
     ? decodeTPCollectionURN(collection.urn!)
     : { urn_suffix: null, third_party_id: null }
@@ -78,8 +78,8 @@ export function toDBCollection(
  *
  * @param urn - The URN to be checked.
  */
-export function isTPCollectionURN(urn: string) {
-  return tpwCollectionURNRegex.test(urn)
+export function hasTPCollectionURN(collection: FullCollection) {
+  return collection.urn && tpwCollectionURNRegex.test(collection.urn)
 }
 
 /**

--- a/src/Collection/utils.ts
+++ b/src/Collection/utils.ts
@@ -51,9 +51,9 @@ export function toFullCollection(
 export function toDBCollection(
   collection: FullCollection
 ): CollectionAttributes {
-  const isTPW = isTPCollectionURN(collection.urn)
+  const isTPW = collection.urn && isTPCollectionURN(collection.urn)
   const decodedURN = isTPW
-    ? decodeTPCollectionURN(collection.urn)
+    ? decodeTPCollectionURN(collection.urn!)
     : { urn_suffix: null, third_party_id: null }
 
   let urn_suffix = decodedURN.urn_suffix


### PR DESCRIPTION
@LautaroPetaccio what do you think of this? creating a valid URN for a collection on create (from the front-end) is abit of a hassle and it's not really necessary

As it stands and without this change, creating a DCL collection from the frontend will fail