### PR TITLE
fix: the urn prefix is already present on third party collection ids

### DIFF
--- a/src/Collection/Collection.router.spec.ts
+++ b/src/Collection/Collection.router.spec.ts
@@ -783,7 +783,7 @@ describe('Collection router', () => {
       thirdPartyDbCollection = {
         ...collectionAttributesMock,
         urn_suffix: 'thesuffix',
-        third_party_id: 'some:third-party-id',
+        third_party_id: 'urn:decentraland:some:third-party-id',
       }
       ;(Collection.find as jest.Mock).mockReturnValueOnce([dbCollection])
       ;(Collection.findByContractAddresses as jest.Mock).mockReturnValueOnce([])
@@ -814,7 +814,7 @@ describe('Collection router', () => {
               {
                 ...toResultCollection(thirdPartyDbCollection),
                 eth_address: wallet.address,
-                urn: `urn:decentraland:ropsten:collections-thirdparty:${thirdPartyDbCollection.third_party_id}:${thirdPartyDbCollection.urn_suffix}`,
+                urn: `${thirdPartyDbCollection.third_party_id}:${thirdPartyDbCollection.urn_suffix}`,
               },
             ],
             ok: true,

--- a/src/Collection/Collection.router.spec.ts
+++ b/src/Collection/Collection.router.spec.ts
@@ -783,7 +783,8 @@ describe('Collection router', () => {
       thirdPartyDbCollection = {
         ...collectionAttributesMock,
         urn_suffix: 'thesuffix',
-        third_party_id: 'urn:decentraland:some:third-party-id',
+        third_party_id:
+          'urn:decentraland:mumbai:collections-thirdparty:third-party-id',
       }
       ;(Collection.find as jest.Mock).mockReturnValueOnce([dbCollection])
       ;(Collection.findByContractAddresses as jest.Mock).mockReturnValueOnce([])

--- a/src/Collection/utils.ts
+++ b/src/Collection/utils.ts
@@ -21,7 +21,7 @@ export function getThirdPartyCollectionURN(
   third_party_id: string,
   urn_suffix: string
 ) {
-  return `urn:decentraland:${getCurrentNetworkURNProtocol()}:collections-thirdparty:${third_party_id}:${urn_suffix}`
+  return `${third_party_id}:${urn_suffix}`
 }
 
 /**


### PR DESCRIPTION
From:
`urn:decentraland:ropsten:collections-thirdparty:urn:decentraland:mumbai:collections-thirdparty:thirdparty2:collection-id`

To
`urn:decentraland:mumbai:collections-thirdparty:thirdparty2:collection-id`