### PR TITLE
feat: return owner (eth_address) on TPW Collection creation

### DIFF
--- a/src/Collection/Collection.router.spec.ts
+++ b/src/Collection/Collection.router.spec.ts
@@ -340,7 +340,7 @@ describe('Collection router', () => {
           )
         })
 
-        it('should upsert the collection and respond with the upserted collection', () => {
+        it('should upsert the collection and respond with the upserted collection adding the eth_address', () => {
           return server
             .put(buildURL(url))
             .set(createAuthHeaders('put', url))
@@ -349,7 +349,10 @@ describe('Collection router', () => {
             .then((response: any) => {
               expect(response.body).toEqual({
                 ok: true,
-                data: toFullCollection(newCollectionAttributes),
+                data: {
+                  ...toFullCollection(newCollectionAttributes),
+                  eth_address: wallet.address,
+                },
               })
 
               expect(newCollectionAttributes).toEqual(
@@ -408,7 +411,7 @@ describe('Collection router', () => {
             )
           })
 
-          it('should respond with a 200, the inserted collection and have upserted the collection with the sent collection', () => {
+          it('should respond with a 200, the inserted collection adding address and have upserted the collection with the sent collection', () => {
             return server
               .put(buildURL(url))
               .set(createAuthHeaders('put', url))
@@ -417,7 +420,10 @@ describe('Collection router', () => {
               .then((response: any) => {
                 expect(response.body).toEqual({
                   ok: true,
-                  data: toFullCollection(newCollectionAttributes),
+                  data: {
+                    ...toFullCollection(newCollectionAttributes),
+                    eth_address: wallet.address,
+                  },
                 })
 
                 expect(newCollectionAttributes).toEqual(

--- a/src/Collection/Collection.service.ts
+++ b/src/Collection/Collection.service.ts
@@ -182,7 +182,9 @@ export class CollectionService {
     const attributes = toDBCollection(collectionJSON)
 
     // Should we do something with the salt and the contract address? There's no need to have them
-    return new Collection(attributes).upsert()
+    await new Collection(attributes).upsert()
+
+    return { ...attributes, eth_address }
   }
 
   async isPublished(contractAddress: string) {

--- a/src/Collection/utils.ts
+++ b/src/Collection/utils.ts
@@ -58,14 +58,12 @@ export function toDBCollection(
 
   let urn_suffix = decodedURN.urn_suffix
   let third_party_id = decodedURN.third_party_id
-  let eth_address = isTPW ? '' : collection.eth_address
   let contract_address = isTPW ? null : collection.contract_address
   let salt = isTPW ? '' : collection.salt
 
   return {
     ...utils.omit(collection, ['urn', 'lock']),
     urn_suffix,
-    eth_address,
     contract_address,
     third_party_id,
     salt,

--- a/src/Collection/utils.ts
+++ b/src/Collection/utils.ts
@@ -58,12 +58,14 @@ export function toDBCollection(
 
   let urn_suffix = decodedURN.urn_suffix
   let third_party_id = decodedURN.third_party_id
+  let eth_address = isTPW ? '' : collection.eth_address
   let contract_address = isTPW ? null : collection.contract_address
   let salt = isTPW ? '' : collection.salt
 
   return {
     ...utils.omit(collection, ['urn', 'lock']),
     urn_suffix,
+    eth_address,
     contract_address,
     third_party_id,
     salt,


### PR DESCRIPTION
@LautaroPetaccio What do you think of this change?

If we don't do this (as we already do on the [Collection.service](https://github.com/decentraland/builder-server/blob/master/src/Collection/Collection.service.ts#L294)) the front-end can't tell whose the owner of the newly created TP collection thus it only shows up on refresh