### PR TITLE
fix: Third party endpoint without manager not returning third parties

### DIFF
--- a/src/ThirdParty/ThirdParty.router.spec.ts
+++ b/src/ThirdParty/ThirdParty.router.spec.ts
@@ -23,12 +23,12 @@ describe('ThirdParty router', () => {
       thirdParty: { name: 'a name', description: 'a description' },
     }
     fragments = [
-      { id: '1', managers: ['0x1'], maxItems: 3, totalItems: 2, metadata },
+      { id: '1', managers: ['0x1'], maxItems: '3', totalItems: '2', metadata },
       {
         id: '2',
         managers: ['0x2', '0x3'],
-        maxItems: 2,
-        totalItems: 1,
+        maxItems: '2',
+        totalItems: '1',
         metadata,
       },
     ]

--- a/src/ThirdParty/ThirdParty.router.ts
+++ b/src/ThirdParty/ThirdParty.router.ts
@@ -1,7 +1,7 @@
 import { server } from 'decentraland-server'
 
 import { Router } from '../common/Router'
-import { withAuthentication, AuthRequest } from '../middleware/authentication'
+import { AuthRequest, withAuthentication } from '../middleware/authentication'
 import { thirdPartyAPI } from '../ethereum/api/thirdParty'
 import { ThirdParty } from './ThirdParty.types'
 import { toThirdParty } from './utils'
@@ -19,13 +19,12 @@ export class ThirdPartyRouter extends Router {
   }
 
   async getThirdParties(req: AuthRequest): Promise<ThirdParty[]> {
-    let manager = ''
+    let manager: string | undefined
     try {
       manager = server.extractFromReq(req, 'manager')
     } catch (e) {
       // We support empty manager filters on the query string
     }
-
     const fragments = await thirdPartyAPI.fetchThirdParties(manager)
     return fragments.map(toThirdParty)
   }

--- a/src/ThirdParty/utils.spec.ts
+++ b/src/ThirdParty/utils.spec.ts
@@ -13,8 +13,8 @@ describe('toThirdParty', () => {
       fragment = {
         id: 'some:id',
         managers: ['0x1', '0x2'],
-        maxItems: 1,
-        totalItems: 1,
+        maxItems: '1',
+        totalItems: '1',
         metadata: {
           type: ThirdPartyMetadataType.THIRD_PARTY_V1,
           thirdParty: {
@@ -47,8 +47,8 @@ describe('toThirdParty', () => {
       fragment = {
         id: 'some:other:id',
         managers: ['0x2'],
-        maxItems: 2,
-        totalItems: 1,
+        maxItems: '2',
+        totalItems: '1',
         metadata: {
           type: ThirdPartyMetadataType.THIRD_PARTY_V1,
           thirdParty: null,

--- a/src/ethereum/api/fragments.ts
+++ b/src/ethereum/api/fragments.ts
@@ -146,8 +146,8 @@ export type CollectionFragment = {
 export type ThirdPartyFragment = {
   id: string
   managers: string[]
-  maxItems: number
-  totalItems: number
+  maxItems: string
+  totalItems: string
   metadata: ThirdPartyMetadata
 }
 

--- a/src/ethereum/api/thirdParty.ts
+++ b/src/ethereum/api/thirdParty.ts
@@ -65,11 +65,11 @@ const getThirdPartyCollectionItemsQuery = () => gql`
 
 export class ThirdPartyAPI extends BaseGraphAPI {
   fetchThirdParties = async (
-    manager: string = ''
+    manager?: string
   ): Promise<ThirdPartyFragment[]> => {
     return this.paginate(['thirdParties'], {
       query: getThirdPartiesQuery(),
-      variables: { managers: [manager.toLowerCase()] },
+      variables: { managers: manager ? [manager.toLowerCase()] : [] },
     })
   }
 


### PR DESCRIPTION
This PR does the following:
- Fixes the third party registry controller and query method to return all third parties if a manager is not specified.
- Fixes the `ThirdPartyFragment` to reflect that `maxItems` and `totalItems` are strings.