### PR TITLE
feat: Only allow one default cache update at the time

### DIFF
--- a/src/AssetPack/AssetPack.router.ts
+++ b/src/AssetPack/AssetPack.router.ts
@@ -341,7 +341,7 @@ export class AssetPackRouter extends Router {
       this.defaultAssetPacks.length === 0
 
     // This is to wait for the cache to be completed if there's no cache ready.
-    // It will execute only the first time the server is up, as after the first fetch
+    // It will execute only the first time the server is up, and after the first fetch
     // the default asset packs will be cached.
     if (this.isUpdatingDefaultAssetPacksCache && defaultAssetPacksIsNotCached) {
       await this.defaultAssetPacksCachePromise


### PR DESCRIPTION
This PR changes the way we're updating the default asset packs cache with a mechanism that does the following:
- If there's no cache and someone is retrieving the default asset packs, wait for the asset packs to be retrieved before responding them. This is to prevent responding with an error or invalid data.
- If there's cache and someone is retrieving an updated version of the default asset packs, respond with the old asset packs until the new ones are updated. This is to not queue unnecessary responses.
- If there's no cache to retrieve and there's no-one retrieving the default asset packs to cache them, set a flag to signal that there's a cache update in progress and set a promise so other requests can wait for it to be completed if there's no cache.