### PR TITLE
feat: Move the upsert of a DCL item to the item service

### DIFF
--- a/src/Item/Item.errors.ts
+++ b/src/Item/Item.errors.ts
@@ -1,5 +1,8 @@
 export enum ItemAction {
   DELETE = 'deleted',
+  INSERT = 'inserted',
+  UPSERT = 'inserted or updated',
+  RARITY_UPDATE = 'updated with a new rarity',
 }
 
 export enum ItemType {
@@ -22,7 +25,6 @@ export class ThirdPartyItemAlreadyPublishedError extends Error {
 export class DCLItemAlreadyPublishedError extends Error {
   constructor(
     public id: string,
-    public blockchainItemId: string,
     public contractAddress: string,
     action: ItemAction
   ) {
@@ -41,5 +43,27 @@ export class CollectionForItemLockedError extends Error {
 export class InconsistentItemError extends Error {
   constructor(public id: string, message: string) {
     super(message)
+  }
+}
+
+export class ItemCantBeMovedFromCollectionError extends Error {
+  constructor(public id: string) {
+    super("Item can't change between collections")
+  }
+}
+
+export class UnauthorizedToUpsertError extends Error {
+  constructor(public id: string, public eth_address: string) {
+    super('The user is unauthorized to upsert the collection.')
+  }
+}
+
+export class UnauthorizedToChangeToCollection extends Error {
+  constructor(
+    public id: string,
+    public eth_address: string,
+    public collection_id: string
+  ) {
+    super("The new collection for the item isn't owned by the same owner")
   }
 }

--- a/src/Item/Item.errors.ts
+++ b/src/Item/Item.errors.ts
@@ -48,7 +48,7 @@ export class InconsistentItemError extends Error {
 
 export class ItemCantBeMovedFromCollectionError extends Error {
   constructor(public id: string) {
-    super("Item can't change between collections")
+    super("Item can't change between collections.")
   }
 }
 
@@ -64,6 +64,6 @@ export class UnauthorizedToChangeToCollection extends Error {
     public eth_address: string,
     public collection_id: string
   ) {
-    super("The new collection for the item isn't owned by the same owner")
+    super("The new collection for the item isn't owned by the same owner.")
   }
 }

--- a/src/Item/Item.router.spec.ts
+++ b/src/Item/Item.router.spec.ts
@@ -403,7 +403,7 @@ describe('Item router', () => {
             collection_id: dbItem.collection_id,
           },
           error:
-            "The new collection for the item isn't owned by the same owner",
+            "The new collection for the item isn't owned by the same owner.",
           ok: false,
         })
       })
@@ -429,7 +429,7 @@ describe('Item router', () => {
 
         expect(response.body).toEqual({
           data: { id: dbItem.id },
-          error: "Item can't change between collections",
+          error: "Item can't change between collections.",
           ok: false,
         })
       })

--- a/src/Item/Item.router.spec.ts
+++ b/src/Item/Item.router.spec.ts
@@ -26,7 +26,7 @@ import { Item } from './Item.model'
 import { hasAccess } from './access'
 import { ItemAttributes, ItemRarity } from './Item.types'
 import { peerAPI, Wearable } from '../ethereum/api/peer'
-import { CollectionFragment, ItemFragment } from '../ethereum/api/fragments'
+import { ItemFragment } from '../ethereum/api/fragments'
 import { STATUS_CODES } from '../common/HTTPError'
 import { Bridge } from '../ethereum/api/Bridge'
 import { thirdPartyAPI } from '../ethereum/api/thirdParty'
@@ -314,8 +314,6 @@ describe('Item router', () => {
 
   describe('when upserting an item', () => {
     const mockCollection = Collection as jest.Mocked<typeof Collection>
-    const mockPeer = peerAPI as jest.Mocked<typeof peerAPI>
-    const mockCollectionApi = collectionAPI as jest.Mocked<typeof collectionAPI>
     const mockItem = Item as jest.MockedClass<typeof Item> &
       jest.Mocked<typeof Item>
 
@@ -341,34 +339,6 @@ describe('Item router', () => {
       })
     })
 
-    describe('and is_approved or is_published exist in the payload item', () => {
-      const testProperty = async (prop: 'is_published' | 'is_approved') => {
-        const response = await server
-          .put(buildURL(url))
-          .send({ item: { ...dbItem, [prop]: true } })
-          .set(createAuthHeaders('put', url))
-          .expect(STATUS_CODES.unauthorized)
-
-        expect(response.body).toEqual({
-          data: { id: dbItem.id, eth_address: wallet.address },
-          error: 'Can not change is_published or is_approved property',
-          ok: false,
-        })
-      }
-
-      describe('having is_approved present', () => {
-        it('should fail with with cant set is approved or is published message', async () => {
-          testProperty('is_approved')
-        })
-      })
-
-      describe('having is_published present', () => {
-        it('should fail with with cant set is approved or is published message', async () => {
-          testProperty('is_published')
-        })
-      })
-    })
-
     describe('and the user upserting is not authorized to do so', () => {
       beforeEach(() => {
         mockOwnableCanUpsert(Item, dbItem.id, wallet.address, false)
@@ -382,7 +352,7 @@ describe('Item router', () => {
 
         expect(response.body).toEqual({
           data: { id: dbItem.id, eth_address: wallet.address },
-          error: 'Unauthorized user',
+          error: 'The user is unauthorized to upsert the collection.',
           ok: false,
         })
       })
@@ -391,6 +361,7 @@ describe('Item router', () => {
     describe('and the collection provided in the payload does not exists in the db', () => {
       beforeEach(() => {
         mockOwnableCanUpsert(Item, dbItem.id, wallet.address, true)
+        mockCollection.findOne.mockResolvedValueOnce(undefined)
       })
 
       it('should fail with collection not found message', async () => {
@@ -402,7 +373,7 @@ describe('Item router', () => {
 
         expect(response.body).toEqual({
           data: { collectionId: dbItem.collection_id },
-          error: 'Collection not found',
+          error: "The collection doesn't exist.",
           ok: false,
         })
       })
@@ -431,7 +402,8 @@ describe('Item router', () => {
             eth_address: wallet.address,
             collection_id: dbItem.collection_id,
           },
-          error: 'Unauthorized user',
+          error:
+            "The new collection for the item isn't owned by the same owner",
           ok: false,
         })
       })
@@ -466,7 +438,6 @@ describe('Item router', () => {
     describe('when the collection given for the item is locked', () => {
       beforeEach(() => {
         mockOwnableCanUpsert(Item, dbItem.id, wallet.address, true)
-        mockPeer.fetchWearables.mockResolvedValueOnce([{}] as Wearable[])
         mockCollection.findOne.mockResolvedValueOnce({
           collection_id: dbItem.collection_id,
           eth_address: wallet.address,
@@ -492,7 +463,8 @@ describe('Item router', () => {
             data: {
               id: dbItem.id,
             },
-            error: "Locked collection items can't be updated",
+            error:
+              "The collection for the item is locked. The item can't be inserted or updated.",
             ok: false,
           })
         })
@@ -501,30 +473,33 @@ describe('Item router', () => {
 
     describe('when the collection given for the item is already published', () => {
       beforeEach(() => {
+        dbItem.collection_id = collectionAttributesMock.id
         mockOwnableCanUpsert(Item, dbItem.id, wallet.address, true)
-        mockPeer.fetchWearables.mockResolvedValueOnce([{}] as Wearable[])
         mockCollection.findOne.mockResolvedValueOnce({
+          ...collectionAttributesMock,
           collection_id: dbItem.collection_id,
           eth_address: wallet.address,
           contract_address: Wallet.createRandom().address,
         })
-
-        mockCollectionApi.fetchCollection.mockResolvedValueOnce(
-          {} as CollectionFragment
-        )
+        mockIsCollectionPublished(collectionAttributesMock.id, true)
       })
 
-      describe('and the item is being upserted for the first time', () => {
+      describe('and the item is being inserted', () => {
+        beforeEach(() => {
+          mockItem.findOne.mockResolvedValueOnce(undefined)
+        })
+
         it('should fail with can not add item to published collection message', async () => {
           const response = await server
             .put(buildURL(url))
             .send({ item: dbItem })
             .set(createAuthHeaders('put', url))
-            .expect(STATUS_CODES.badRequest)
+            .expect(STATUS_CODES.conflict)
 
           expect(response.body).toEqual({
             data: { id: dbItem.id },
-            error: "Items can't be added to a published collection",
+            error:
+              "The collection that contains this item has been already published. The item can't be inserted.",
             ok: false,
           })
         })
@@ -540,11 +515,12 @@ describe('Item router', () => {
             .put(buildURL(url))
             .send({ item: { ...dbItem, collection_id: null } })
             .set(createAuthHeaders('put', url))
-            .expect(STATUS_CODES.badRequest)
+            .expect(STATUS_CODES.conflict)
 
           expect(response.body).toEqual({
             data: { id: dbItem.id },
-            error: "Items can't be removed from a pubished collection",
+            error:
+              "The collection that contains this item has been already published. The item can't be deleted.",
             ok: false,
           })
         })
@@ -560,16 +536,14 @@ describe('Item router', () => {
             .put(buildURL(url))
             .send({ item: { ...dbItem, rarity: ItemRarity.EPIC } })
             .set(createAuthHeaders('put', url))
-            .expect(STATUS_CODES.badRequest)
+            .expect(STATUS_CODES.conflict)
 
           expect(response.body).toEqual({
             data: {
               id: dbItem.id,
-              current: dbItem.rarity,
-              other: ItemRarity.EPIC,
             },
             error:
-              "An item rarity from a published collection can't be changed",
+              "The collection that contains this item has been already published. The item can't be updated with a new rarity.",
             ok: false,
           })
         })
@@ -579,7 +553,6 @@ describe('Item router', () => {
     describe('and all the conditions for success are given', () => {
       beforeEach(() => {
         mockOwnableCanUpsert(Item, dbItem.id, wallet.address, true)
-        mockPeer.fetchWearables.mockResolvedValueOnce([] as Wearable[])
         mockCollection.findOne.mockResolvedValueOnce({
           collection_id: dbItem.collection_id,
           eth_address: wallet.address,
@@ -706,7 +679,6 @@ describe('Item router', () => {
                     "The collection that contains this item has been already published. The item can't be deleted.",
                   data: {
                     id: dbItem.id,
-                    blockchain_item_id: dbItem.blockchain_item_id,
                     contract_address: collectionAttributesMock.contract_address,
                   },
                   ok: false,

--- a/src/Item/Item.service.ts
+++ b/src/Item/Item.service.ts
@@ -111,10 +111,10 @@ export class ItemService {
     }
   }
 
-  private async checkIfItemIsMovedToAnotherCollection(
+  private checkIfItemIsMovedToAnotherCollection(
     itemToUpsert: FullItem,
     dbItem: ItemAttributes
-  ): Promise<void> {
+  ): void {
     const areBothCollectionIdsDefined =
       itemToUpsert.collection_id && dbItem.collection_id
 
@@ -138,7 +138,7 @@ export class ItemService {
 
     const dbItem = await Item.findOne<ItemAttributes>(item.id)
     if (dbItem) {
-      await this.checkIfItemIsMovedToAnotherCollection(item, dbItem)
+      this.checkIfItemIsMovedToAnotherCollection(item, dbItem)
     }
 
     const collectionId = item.collection_id || dbItem?.collection_id

--- a/src/Item/Item.service.ts
+++ b/src/Item/Item.service.ts
@@ -111,7 +111,7 @@ export class ItemService {
     }
   }
 
-  private checkIfItemIsMovedToAnotherCollection(
+  private checkItemIsMovedToAnotherCollection(
     itemToUpsert: FullItem,
     dbItem: ItemAttributes
   ): void {
@@ -138,7 +138,7 @@ export class ItemService {
 
     const dbItem = await Item.findOne<ItemAttributes>(item.id)
     if (dbItem) {
-      this.checkIfItemIsMovedToAnotherCollection(item, dbItem)
+      this.checkItemIsMovedToAnotherCollection(item, dbItem)
     }
 
     const collectionId = item.collection_id || dbItem?.collection_id

--- a/src/Item/Item.service.ts
+++ b/src/Item/Item.service.ts
@@ -1,6 +1,8 @@
 import { CollectionService } from '../Collection/Collection.service'
 import { isTPCollection } from '../Collection/utils'
+import { Bridge } from '../ethereum/api/Bridge'
 import { thirdPartyAPI } from '../ethereum/api/thirdParty'
+import { Ownable } from '../Ownable'
 import {
   CollectionForItemLockedError,
   ItemAction,
@@ -8,10 +10,13 @@ import {
   InconsistentItemError,
   DCLItemAlreadyPublishedError,
   ThirdPartyItemAlreadyPublishedError,
+  ItemCantBeMovedFromCollectionError,
+  UnauthorizedToUpsertError,
+  UnauthorizedToChangeToCollection,
 } from './Item.errors'
 import { Item } from './Item.model'
-import { ItemAttributes } from './Item.types'
-import { buildTPItemURN, isTPItem } from './utils'
+import { FullItem, ItemAttributes } from './Item.types'
+import { buildTPItemURN, isTPItem, toDBItem } from './utils'
 
 export class ItemService {
   private collectionService = new CollectionService()
@@ -43,7 +48,6 @@ export class ItemService {
       ) {
         throw new DCLItemAlreadyPublishedError(
           dbItem.id,
-          dbItem.blockchain_item_id!,
           dbCollection.contract_address!,
           ItemAction.DELETE
         )
@@ -105,5 +109,114 @@ export class ItemService {
     } else {
       await this.deleteDCLItem(dbItem)
     }
+  }
+
+  private async checkIfItemIsMovedToAnotherCollection(
+    itemToUpsert: FullItem,
+    dbItem: ItemAttributes
+  ): Promise<void> {
+    const areBothCollectionIdsDefined =
+      itemToUpsert.collection_id && dbItem.collection_id
+
+    const isItemCollectionBeingChanged =
+      areBothCollectionIdsDefined &&
+      itemToUpsert.collection_id !== dbItem.collection_id
+
+    if (isItemCollectionBeingChanged) {
+      throw new ItemCantBeMovedFromCollectionError(itemToUpsert.id)
+    }
+  }
+
+  private async upsertDCLItem(
+    item: FullItem,
+    eth_address: string
+  ): Promise<FullItem> {
+    const canUpsert = await new Ownable(Item).canUpsert(item.id, eth_address)
+    if (!canUpsert) {
+      throw new UnauthorizedToUpsertError(item.id, eth_address)
+    }
+
+    const dbItem = await Item.findOne<ItemAttributes>(item.id)
+    if (dbItem) {
+      await this.checkIfItemIsMovedToAnotherCollection(item, dbItem)
+    }
+
+    const collectionId = item.collection_id || dbItem?.collection_id
+    const dbCollection = collectionId
+      ? await this.collectionService.getDBCollection(collectionId)
+      : undefined
+
+    if (dbCollection) {
+      const isCollectionOwnerDifferent =
+        dbCollection.eth_address.toLowerCase() !== eth_address
+
+      if (isCollectionOwnerDifferent) {
+        throw new UnauthorizedToChangeToCollection(
+          item.id,
+          eth_address,
+          item.collection_id!
+        )
+      }
+
+      const isDbCollectionPublished =
+        dbCollection &&
+        (await this.collectionService.isPublished(
+          dbCollection.contract_address!
+        ))
+
+      if (isDbCollectionPublished) {
+        // Prohibits adding new items to a published collection
+        if (!dbItem) {
+          throw new DCLItemAlreadyPublishedError(
+            item.id,
+            dbCollection.contract_address!,
+            ItemAction.INSERT
+          )
+        }
+
+        // Prohibits removing an item from a published collection
+        const isItemBeingRemovedFromCollection =
+          !item.collection_id && dbItem.collection_id
+
+        if (isItemBeingRemovedFromCollection) {
+          throw new DCLItemAlreadyPublishedError(
+            item.id,
+            dbCollection.contract_address!,
+            ItemAction.DELETE
+          )
+        }
+
+        // Prohibits changing the rarity of a published item.
+        const areBothRaritiesDefined = item.rarity && dbItem.rarity
+
+        const isRarityBeingChanged =
+          areBothRaritiesDefined && item.rarity !== dbItem.rarity
+
+        if (isRarityBeingChanged) {
+          throw new DCLItemAlreadyPublishedError(
+            item.id,
+            dbCollection.contract_address!,
+            ItemAction.RARITY_UPDATE
+          )
+        }
+      } else if (this.collectionService.isLockActive(dbCollection.lock)) {
+        throw new CollectionForItemLockedError(item.id, ItemAction.UPSERT)
+      }
+    }
+
+    const attributes = toDBItem({
+      ...item,
+      eth_address,
+    })
+
+    const upsertedItem: ItemAttributes = await new Item(attributes).upsert()
+    return Bridge.toFullItem(upsertedItem)
+  }
+
+  public async upsertItem(
+    item: FullItem,
+    eth_address: string
+  ): Promise<FullItem> {
+    return this.upsertDCLItem(item, eth_address)
   }
 }


### PR DESCRIPTION
This PR does the following:
- Moves the item upsert code, that inserts or updates an item in the DB to the item service.
- Changes the upsert controller code to use the item service and handle errors.
- Removes an unnecessary DB request to get the collection of the item.