### PR TITLE
feat: Add HEADER redirect to contents

### DIFF
--- a/src/S3/S3Router.spec.ts
+++ b/src/S3/S3Router.spec.ts
@@ -18,14 +18,13 @@ describe('S3 router', () => {
       url = `/storage/contents/${fileName}`
     })
 
-    it('should respond with a cached 301 redirecting to the S3 file', () => {
-      return server
+    it('should respond with a cached 301 redirecting to the S3 file', async () => {
+      await server
         .get(buildURL(url))
         .set(createAuthHeaders('get', url))
         .expect('Location', `${getBucketURL()}/contents/${fileName}`)
         .expect('Cache-Control', 'public,max-age=31536000,immutable')
         .expect(301)
-        .then(() => undefined)
     })
   })
 
@@ -34,14 +33,13 @@ describe('S3 router', () => {
       url = `/storage/contents/${fileName}`
     })
 
-    it('should respond with a cached 301 redirecting to the S3 file', () => {
-      return server
+    it('should respond with a cached 301 redirecting to the S3 file', async () => {
+      await server
         .get(buildURL(url))
         .set(createAuthHeaders('head', url))
         .expect('Location', `${getBucketURL()}/contents/${fileName}`)
         .expect('Cache-Control', 'public,max-age=31536000,immutable')
         .expect(301)
-        .then(() => undefined)
     })
   })
 })

--- a/src/S3/S3Router.spec.ts
+++ b/src/S3/S3Router.spec.ts
@@ -1,0 +1,47 @@
+import supertest from 'supertest'
+import { buildURL, createAuthHeaders } from '../../spec/utils'
+import { app } from '../server'
+import { getBucketURL } from './s3'
+
+const server = supertest(app.getApp())
+
+describe('S3 router', () => {
+  let fileName: string
+  let url: string
+
+  beforeEach(() => {
+    fileName = 'aFile'
+  })
+
+  describe('when getting the contents of a file', () => {
+    beforeEach(() => {
+      url = `/storage/contents/${fileName}`
+    })
+
+    it('should respond with a cached 301 redirecting to the S3 file', () => {
+      return server
+        .get(buildURL(url))
+        .set(createAuthHeaders('get', url))
+        .expect('Location', `${getBucketURL()}/contents/${fileName}`)
+        .expect('Cache-Control', 'public,max-age=31536000,immutable')
+        .expect(301)
+        .then(() => undefined)
+    })
+  })
+
+  describe('when getting the information of a file', () => {
+    beforeEach(() => {
+      url = `/storage/contents/${fileName}`
+    })
+
+    it('should respond with a cached 301 redirecting to the S3 file', () => {
+      return server
+        .get(buildURL(url))
+        .set(createAuthHeaders('head', url))
+        .expect('Location', `${getBucketURL()}/contents/${fileName}`)
+        .expect('Cache-Control', 'public,max-age=31536000,immutable')
+        .expect(301)
+        .then(() => undefined)
+    })
+  })
+})

--- a/src/S3/S3Router.ts
+++ b/src/S3/S3Router.ts
@@ -19,6 +19,11 @@ export class S3Router extends Router {
      * Get an asset file by file id (also contains items)
      */
     this.router.get('/storage/contents/:filename', this.handleContents)
+
+    /**
+     * Get the response headers for a file
+     */
+    this.router.head('/storage/contents/:filename', this.handleContents)
   }
 
   private buildRedirectUrl(model: S3Model, filename: string) {


### PR DESCRIPTION
This PR adds a 301 redirect to the contents endpoint to get the sizes of the files without downloading them.