### PR TITLE
feat: Add pattern check to the name and the description of the items

### DIFF
--- a/src/Item/Item.router.spec.ts
+++ b/src/Item/Item.router.spec.ts
@@ -326,6 +326,59 @@ describe('Item router', () => {
       itemToUpsert = utils.omit(dbItem, ['created_at', 'updated_at'])
     })
 
+    describe('and the item inserted has an invalid name', () => {
+      it("should fail with a message indicating that the name doesn't match the pattern", () => {
+        return server
+          .put(buildURL(url))
+          .send({ item: { ...itemToUpsert, name: 'anInvalid:name' } })
+          .set(createAuthHeaders('put', url))
+          .expect(STATUS_CODES.badRequest)
+          .then((response: any) => {
+            expect(response.body).toEqual({
+              data: [
+                {
+                  dataPath: '/item/name',
+                  keyword: 'pattern',
+                  message: 'should match pattern "^[^:]*$"',
+                  params: { pattern: '^[^:]*$' },
+                  schemaPath: '#/properties/item/properties/name/pattern',
+                },
+              ],
+              error: 'Invalid request body',
+              ok: false,
+            })
+          })
+      })
+    })
+
+    describe('and the item inserted has an invalid description', () => {
+      it("should fail with a message indicating that the description doesn't match the pattern", () => {
+        return server
+          .put(buildURL(url))
+          .send({
+            item: { ...itemToUpsert, description: 'anInvalid:nescription' },
+          })
+          .set(createAuthHeaders('put', url))
+          .expect(STATUS_CODES.badRequest)
+          .then((response: any) => {
+            expect(response.body).toEqual({
+              data: [
+                {
+                  dataPath: '/item/description',
+                  keyword: 'pattern',
+                  message: 'should match pattern "^[^:]*$"',
+                  params: { pattern: '^[^:]*$' },
+                  schemaPath:
+                    '#/properties/item/properties/description/pattern',
+                },
+              ],
+              error: 'Invalid request body',
+              ok: false,
+            })
+          })
+      })
+    })
+
     describe('and the param id is different from payload id', () => {
       it('should fail with body and url ids do not match message', async () => {
         const response = await server

--- a/src/Item/Item.schema.ts
+++ b/src/Item/Item.schema.ts
@@ -8,8 +8,12 @@ export const itemSchema = Object.freeze({
   properties: {
     id: { type: 'string', format: 'uuid' },
     urn: { type: ['string', 'null'] },
-    name: { type: 'string', maxLength: 32 },
-    description: { type: ['string', 'null'], maxLength: 64 },
+    name: { type: 'string', maxLength: 32, pattern: '^[^:]*$' },
+    description: {
+      type: ['string', 'null'],
+      maxLength: 64,
+      pattern: '^[^:]*$',
+    },
     thumbnail: { type: 'string' },
     eth_address: { type: 'string' },
     collection_id: { type: ['string', 'null'], format: 'uuid' },


### PR DESCRIPTION
This PR adds a simple pattern to exclude any names and descriptions of items that disallows using `:` in them.