### PR TITLE
fix: Item's URN suffix must be unique

### DIFF
--- a/migrations/1641484605043_make-items-urn-suffix-unique.ts
+++ b/migrations/1641484605043_make-items-urn-suffix-unique.ts
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder } from 'node-pg-migrate'
+import { Item } from '../src/Item/Item.model'
+
+const tableName = Item.tableName
+const urnSuffixColumnName = 'urn_suffix'
+const constraintName = `${urnSuffixColumnName}_unique`
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createConstraint(tableName, constraintName, {
+    unique: [urnSuffixColumnName],
+  })
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint(tableName, constraintName)
+}

--- a/migrations/1641484605043_make-items-urn-suffix-unique.ts
+++ b/migrations/1641484605043_make-items-urn-suffix-unique.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { MigrationBuilder } from 'node-pg-migrate'
 import { Item } from '../src/Item/Item.model'
 

--- a/migrations/1641484605043_make-items-urn-suffix-unique.ts
+++ b/migrations/1641484605043_make-items-urn-suffix-unique.ts
@@ -4,11 +4,12 @@ import { Item } from '../src/Item/Item.model'
 
 const tableName = Item.tableName
 const urnSuffixColumnName = 'urn_suffix'
+const collectionIdColumnName = 'collection_id'
 const constraintName = `${urnSuffixColumnName}_unique`
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.createConstraint(tableName, constraintName, {
-    unique: [urnSuffixColumnName],
+    unique: [collectionIdColumnName, urnSuffixColumnName],
   })
 }
 

--- a/migrations/1641484605043_make-items-urn-suffix-unique.ts
+++ b/migrations/1641484605043_make-items-urn-suffix-unique.ts
@@ -5,7 +5,7 @@ import { Item } from '../src/Item/Item.model'
 const tableName = Item.tableName
 const urnSuffixColumnName = 'urn_suffix'
 const collectionIdColumnName = 'collection_id'
-const constraintName = `${urnSuffixColumnName}_unique`
+const constraintName = `${collectionIdColumnName}_${urnSuffixColumnName}_unique`
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.createConstraint(tableName, constraintName, {


### PR DESCRIPTION
This PR adds a new migration that makes the item's URN suffix unique.