### PR TITLE
fix: DCL item upsert url

### DIFF
--- a/src/Item/Item.router.spec.ts
+++ b/src/Item/Item.router.spec.ts
@@ -817,7 +817,7 @@ describe('Item router', () => {
 
     describe('and the item is a DCL item', () => {
       beforeEach(() => {
-        itemToUpsert = { ...itemToUpsert, urn: null }
+        itemToUpsert = { ...itemToUpsert, urn }
         collectionMock = {
           ...collectionMock,
           urn_suffix: null,

--- a/src/Item/utils.ts
+++ b/src/Item/utils.ts
@@ -19,9 +19,10 @@ export function getDecentralandItemURN(
 export function toDBItem(item: FullItem): ItemAttributes {
   const attributes = {
     ...item,
-    urn_suffix: item.urn
-      ? decodeThirdPartyItemURN(item.urn).item_urn_suffix
-      : null,
+    urn_suffix:
+      item.urn && isTPItemURN(item.urn)
+        ? decodeThirdPartyItemURN(item.urn).item_urn_suffix
+        : null,
   }
   return utils.omit(attributes, [
     'urn',
@@ -64,6 +65,10 @@ export function decodeThirdPartyItemURN(
     collection_urn_suffix: matches[3],
     item_urn_suffix: matches[4],
   }
+}
+
+export function isTPItemURN(itemURN: string): boolean {
+  return tpwItemURNRegex.test(itemURN)
 }
 
 // TODO: @TPW: implement this


### PR DESCRIPTION
This PR changes the way that the `urn_suffix` is built in the DBItem by checking first if it's a TP item.