### PR TITLE
fix: Items consolidation without urn

### DIFF
--- a/src/ethereum/api/Bridge.ts
+++ b/src/ethereum/api/Bridge.ts
@@ -98,7 +98,10 @@ export class Bridge {
 
         fullItem = Bridge.mergeTPItem(item, remoteItem, catalystItem)
       } else {
-        fullItem = Bridge.toFullItem(item)
+        fullItem = Bridge.toFullItem(
+          item,
+          dbTPCollectionsIndex[item.collection_id!]
+        )
       }
 
       fullItems.push(fullItem)


### PR DESCRIPTION
This PR adds the missing collection to the construction of a "FullItem" so its URN can get built.