### PR TITLE
fix: Prevent uploading broken representations

### DIFF
--- a/spec/mocks/items.ts
+++ b/spec/mocks/items.ts
@@ -12,11 +12,12 @@ import {
   ItemType,
   ThirdPartyItemAttributes,
 } from '../../src/Item/Item.types'
-import { dbCollectionMock, dbTPCollectionMock } from './collections'
 import { toUnixTimestamp } from '../../src/utils/parse'
 import { buildTPItemURN } from '../../src/Item/utils'
 import { CollectionAttributes } from '../../src/Collection'
 import { isTPCollection } from '../../src/Collection/utils'
+import { WearableBodyShape } from '../../src/Item/wearable/types'
+import { dbCollectionMock, dbTPCollectionMock } from './collections'
 
 export type ResultItem = Omit<FullItem, 'created_at' | 'updated_at'> & {
   created_at: string
@@ -74,7 +75,15 @@ export const dbItemMock: ItemAttributes = {
   rarity: ItemRarity.COMMON,
   type: ItemType.WEARABLE,
   data: {
-    representations: [],
+    representations: [
+      {
+        bodyShapes: [WearableBodyShape.MALE],
+        mainFile: 'male/M_3LAU_Hat_Blue.glb',
+        contents: ['male/M_3LAU_Hat_Blue.glb'],
+        overrideHides: [],
+        overrideReplaces: [],
+      },
+    ],
     replaces: [],
     hides: [],
     tags: [],
@@ -87,7 +96,11 @@ export const dbItemMock: ItemAttributes = {
     triangles: 5,
     entities: 6,
   },
-  contents: {},
+  contents: {
+    'male/M_3LAU_Hat_Blue.glb':
+      'QmebRdUS12afshxzNtTb2h6UhSXjMrGTGeZWcwwtmhTJng',
+    'thumbnail.png': 'QmPP232rkN2UDg8yGAyJ6hkHGsDFwXivcv9MXFfnW8r34y',
+  },
   created_at: new Date(),
   updated_at: new Date(),
 }

--- a/src/Item/Item.router.spec.ts
+++ b/src/Item/Item.router.spec.ts
@@ -525,6 +525,42 @@ describe('Item router', () => {
         })
       })
 
+      describe("and the item contains a representation with file names that aren't included in the contents", () => {
+        beforeEach(() => {
+          itemToUpsert = {
+            ...itemToUpsert,
+            data: {
+              ...itemToUpsert.data,
+              representations: [
+                {
+                  ...itemToUpsert.data.representations[0],
+                  mainFile: 'some-file-that-does-not-exist.glb',
+                  contents: ['male/another-file-that-doesnt-exist.glb'],
+                },
+              ],
+            },
+          }
+        })
+
+        it('should respond with a 400 and a message signaling that the representation contains files that are not included in the contents', () => {
+          return server
+            .put(buildURL(url))
+            .send({ item: itemToUpsert })
+            .set(createAuthHeaders('put', url))
+            .expect(STATUS_CODES.badRequest)
+            .then((response: any) => {
+              expect(response.body).toEqual({
+                data: {
+                  id: itemToUpsert.id,
+                },
+                error:
+                  "Representation files must be part of the item's content",
+                ok: false,
+              })
+            })
+        })
+      })
+
       describe('and the item is being updated', () => {
         beforeEach(() => {
           mockIsThirdPartyManager(wallet.address, true)

--- a/src/Item/Item.router.ts
+++ b/src/Item/Item.router.ts
@@ -22,7 +22,7 @@ import { NonExistentCollectionError } from '../Collection/Collection.errors'
 import { isCommitteeMember } from '../Committee'
 import { Item } from './Item.model'
 import { ItemAttributes } from './Item.types'
-import { upsertItemSchema } from './Item.schema'
+import { areItemRepresentationsValid, upsertItemSchema } from './Item.schema'
 import { FullItem } from './Item.types'
 import { hasPublicAccess } from './access'
 import { ItemService } from './Item.service'
@@ -278,6 +278,16 @@ export class ItemRouter extends Router {
         {
           urlId: id,
           bodyId: itemJSON.id,
+        },
+        STATUS_CODES.badRequest
+      )
+    }
+
+    if (!areItemRepresentationsValid(itemJSON)) {
+      throw new HTTPError(
+        "Representation files must be part of the item's content",
+        {
+          id,
         },
         STATUS_CODES.badRequest
       )

--- a/src/Item/Item.schema.spec.ts
+++ b/src/Item/Item.schema.spec.ts
@@ -1,0 +1,51 @@
+import { utils } from 'decentraland-commons'
+import { dbItemMock } from '../../spec/mocks/items'
+import { areItemRepresentationsValid } from './Item.schema'
+import { FullItem } from './Item.types'
+
+describe("when checking if and item's representations are valid", () => {
+  let item: FullItem
+
+  beforeEach(() => {
+    item = utils.omit(dbItemMock, ['created_at', 'updated_at'])
+  })
+
+  describe("and the main file of one of the representations is not included in the representation's contents", () => {
+    beforeEach(() => {
+      item.data.representations[0].contents = ['file1.glb']
+      item.data.representations[0].mainFile = 'another-file.glb'
+    })
+
+    it('should return false', () => {
+      expect(areItemRepresentationsValid(item)).toBe(false)
+    })
+  })
+
+  describe("and a file in an item's representations content is is not included in the item's contents", () => {
+    beforeEach(() => {
+      item.data.representations[0].contents = ['file1.glb']
+      item.data.representations[0].mainFile = 'file1.glb'
+      item.contents = {
+        'another-file.glb': 'someHash',
+      }
+    })
+
+    it('should return false', () => {
+      expect(areItemRepresentationsValid(item)).toBe(false)
+    })
+  })
+
+  describe("and all the representations contents are included in the item's contents", () => {
+    beforeEach(() => {
+      item.data.representations[0].contents = ['file1.glb']
+      item.data.representations[0].mainFile = 'file1.glb'
+      item.contents = {
+        'file1.glb': 'someHash',
+      }
+    })
+
+    it('should return true', () => {
+      expect(areItemRepresentationsValid(item)).toBe(true)
+    })
+  })
+})

--- a/src/Item/Item.schema.spec.ts
+++ b/src/Item/Item.schema.spec.ts
@@ -3,7 +3,7 @@ import { dbItemMock } from '../../spec/mocks/items'
 import { areItemRepresentationsValid } from './Item.schema'
 import { FullItem } from './Item.types'
 
-describe("when checking if and item's representations are valid", () => {
+describe("when checking if an item's representations are valid", () => {
   let item: FullItem
 
   beforeEach(() => {

--- a/src/Item/Item.schema.ts
+++ b/src/Item/Item.schema.ts
@@ -1,6 +1,6 @@
 import { matchers } from '../common/matchers'
 import { metricsSchema } from '../Metrics/Metrics.schema'
-import { ItemRarity, ItemType } from './Item.types'
+import { FullItem, ItemRarity, ItemType } from './Item.types'
 import { wearableSchema } from './wearable/types'
 
 // The schema is placed into this file to avoid a circular dependency.
@@ -60,3 +60,12 @@ export const upsertItemSchema = Object.freeze({
   additionalProperties: false,
   required: ['item'],
 })
+
+export function areItemRepresentationsValid(item: FullItem): boolean {
+  const contentFiles = Object.keys(item.contents)
+  return item.data.representations.every(
+    (representation) =>
+      representation.contents.includes(representation.mainFile) &&
+      representation.contents.every((file) => contentFiles.includes(file))
+  )
+}

--- a/src/Item/wearable/types.ts
+++ b/src/Item/wearable/types.ts
@@ -75,6 +75,7 @@ export const wearableSchema = Object.freeze({
           'overrideHides',
         ],
       },
+      minItems: 1,
     },
     replaces: {
       type: 'array',

--- a/src/Item/wearable/types.ts
+++ b/src/Item/wearable/types.ts
@@ -56,6 +56,7 @@ export const wearableSchema = Object.freeze({
           contents: {
             type: 'array',
             items: { type: 'string' },
+            minItems: 1,
           },
           overrideReplaces: {
             type: 'array',


### PR DESCRIPTION
This PR adds a validation to the item's object in the item's upsert that prevents an item from having a representation with contents or a main file that is not included in the item's contents.