### PR TITLE
feat: Add DISTINCT ON itemCurations query

### DIFF
--- a/src/Curation/ItemCuration/ItemCuration.model.ts
+++ b/src/Curation/ItemCuration/ItemCuration.model.ts
@@ -11,9 +11,10 @@ export class ItemCuration extends Model<ItemCurationAttributes> {
   static async findByCollectionId(collectionId: string) {
     // prettier-ignore
     return this.query<ItemCurationAttributes>(SQL`
-    SELECT ic.*
+    SELECT DISTINCT on (i.id) ic.*
       FROM ${raw(this.tableName)} ic
-      INNER JOIN ${raw(Item.tableName)} i ON i.id = ic.item_id AND i.collection_id = ${collectionId}`)
+      INNER JOIN ${raw(Item.tableName)} i ON i.id = ic.item_id AND i.collection_id = ${collectionId} 
+      ORDER BY i.id, ic.created_at DESC`)
   }
 
   static async getItemCurationCountByThirdPartyId(thirdPartyId: string) {


### PR DESCRIPTION
Closes #406 

## Screenshots
Without the new `DISTINCT ON`, it returns multiple `itemCurations` for the same `itemId`:

<img width="394" alt="image" src="https://user-images.githubusercontent.com/8763687/154117418-9306f7af-d049-4f69-8215-7012e053df87.png">


With the `DISTINCT ON`:
<img width="398" alt="image" src="https://user-images.githubusercontent.com/8763687/154117167-0bdcc7c2-d738-421c-aa09-e4470f218cc9.png">

It returns the "newest" one.