### PR TITLE
fix: Remove repeated endpoint

### DIFF
--- a/src/Curation/Curation.router.ts
+++ b/src/Curation/Curation.router.ts
@@ -88,12 +88,6 @@ export class CurationRouter extends Router {
       withAuthentication,
       server.handleRequest(this.insertItemCuration)
     )
-
-    this.router.post(
-      '/items/:id/curation',
-      withAuthentication,
-      server.handleRequest(this.insertItemCuration)
-    )
   }
 
   /**


### PR DESCRIPTION
The `/items/:id/curation` endpoint is instantiated twice, this PR removes one of them.