### PR TITLE
fix: Query for finding non TP items by owner in `/:address/items`

### DIFF
--- a/src/Item/Item.model.ts
+++ b/src/Item/Item.model.ts
@@ -63,4 +63,12 @@ export class Item extends Model<ItemAttributes> {
         INNER JOIN ${raw(Collection.tableName)} c ON i.collection_id = c.id
         WHERE ${where}`)
   }
+
+  static findNonThirdPartyItemsByOwner(owner: string) {
+    return this.query<ItemAttributes>(SQL`
+      SELECT *
+        FROM ${raw(this.tableName)}
+        WHERE eth_address = ${owner}
+        AND urn_suffix IS NULL`)
+  }
 }

--- a/src/Item/Item.router.spec.ts
+++ b/src/Item/Item.router.spec.ts
@@ -297,7 +297,7 @@ describe('Item router', () => {
 
   describe('when getting all the items of an address', () => {
     beforeEach(() => {
-      ;(Item.find as jest.Mock).mockResolvedValueOnce([
+      ;(Item.findNonThirdPartyItemsByOwner as jest.Mock).mockResolvedValueOnce([
         dbItem,
         dbItemNotPublished,
       ])

--- a/src/Item/Item.router.ts
+++ b/src/Item/Item.router.ts
@@ -183,7 +183,7 @@ export class ItemRouter extends Router {
     }
 
     const [dbItems, remoteItems, dbTPItems, itemCurations] = await Promise.all([
-      Item.find<ItemAttributes>({ eth_address, urn_suffix: null }),
+      Item.findNonThirdPartyItemsByOwner(eth_address),
       collectionAPI.fetchItemsByAuthorizedUser(eth_address),
       this.itemService.getTPItemsByManager(eth_address),
       ItemCuration.find<ItemCurationAttributes>(),


### PR DESCRIPTION
`Item.find<ItemAttributes>({ eth_address, urn_suffix: null })` 
Was being mapped to 
`SELECT ... WHERE urn_suffix = null` 
Instead of
`SELECT ... WHERE urn_suffix IS NULL` 
So no results would be returned. 
