### PR TITLE
fix: Find third party ids query

### DIFF
--- a/migrations/migrate.ts
+++ b/migrations/migrate.ts
@@ -17,6 +17,7 @@ export function migrate(
   }
 
   const spawnArgs = [
+    '--no-check-order',
     '--database-url-var',
     'CONNECTION_STRING',
     '--migration-file-language',

--- a/migrations/migrate.ts
+++ b/migrations/migrate.ts
@@ -17,7 +17,6 @@ export function migrate(
   }
 
   const spawnArgs = [
-    '--no-check-order',
     '--database-url-var',
     'CONNECTION_STRING',
     '--migration-file-language',

--- a/src/Item/Item.model.ts
+++ b/src/Item/Item.model.ts
@@ -33,15 +33,14 @@ export class Item extends Model<ItemAttributes> {
   }
 
   static findByThirdPartyIds(thirdPartyIds: string[]) {
+    const itemsTable = raw(this.tableName)
+    const collectionsTable = raw(Collection.tableName)
+
     return this.query<ItemAttributes>(SQL`
-      SELECT ${raw(this.tableName)}.*
-        FROM ${raw(this.tableName)}
-        JOIN ${raw(Collection.tableName)} ON collections.id = ${raw(
-      this.tableName
-    )}.collection_id
-        WHERE ${raw(
-          Collection.tableName
-        )}.third_party_id = ANY(${thirdPartyIds})`)
+      SELECT ${itemsTable}.*
+        FROM ${itemsTable}
+        JOIN ${collectionsTable} ON collections.id = ${itemsTable}.collection_id
+        WHERE ${collectionsTable}.third_party_id = ANY(${thirdPartyIds})`)
   }
 
   static findOrderedByCollectionId(

--- a/src/Item/Item.model.ts
+++ b/src/Item/Item.model.ts
@@ -34,12 +34,14 @@ export class Item extends Model<ItemAttributes> {
 
   static findByThirdPartyIds(thirdPartyIds: string[]) {
     return this.query<ItemAttributes>(SQL`
-      SELECT items.*
-        FROM ${raw(this.tableName)} items 
-        JOIN ${raw(
+      SELECT ${raw(this.tableName)}.*
+        FROM ${raw(this.tableName)}
+        JOIN ${raw(Collection.tableName)} ON collections.id = ${raw(
+      this.tableName
+    )}.collection_id
+        WHERE ${raw(
           Collection.tableName
-        )} collections ON collections.id = item.collection_id
-        WHERE collections.third_party_id = ANY(${thirdPartyIds})`)
+        )}.third_party_id = ANY(${thirdPartyIds})`)
   }
 
   static findOrderedByCollectionId(

--- a/src/Item/Item.model.ts
+++ b/src/Item/Item.model.ts
@@ -39,7 +39,7 @@ export class Item extends Model<ItemAttributes> {
     return this.query<ItemAttributes>(SQL`
       SELECT ${itemsTable}.*
         FROM ${itemsTable}
-        JOIN ${collectionsTable} ON collections.id = ${itemsTable}.collection_id
+        JOIN ${collectionsTable} ON ${collectionsTable}.id = ${itemsTable}.collection_id
         WHERE ${collectionsTable}.third_party_id = ANY(${thirdPartyIds})`)
   }
 

--- a/src/Item/Item.model.ts
+++ b/src/Item/Item.model.ts
@@ -33,14 +33,13 @@ export class Item extends Model<ItemAttributes> {
   }
 
   static findByThirdPartyIds(thirdPartyIds: string[]) {
-    const itemsTable = raw(this.tableName)
-    const collectionsTable = raw(Collection.tableName)
-
     return this.query<ItemAttributes>(SQL`
-      SELECT ${itemsTable}.*
-        FROM ${itemsTable}
-        JOIN ${collectionsTable} ON ${collectionsTable}.id = ${itemsTable}.collection_id
-        WHERE ${collectionsTable}.third_party_id = ANY(${thirdPartyIds})`)
+      SELECT items.*
+        FROM ${raw(this.tableName)} items
+        JOIN ${raw(
+          Collection.tableName
+        )} collections ON collections.id = items.collection_id
+        WHERE collections.third_party_id = ANY(${thirdPartyIds})`)
   }
 
   static findOrderedByCollectionId(


### PR DESCRIPTION
This PR fixes an issue where we were using `item` instead of `items` when naming a table.
The aliases were removed, as the names of the collections are sufficient enough for this query and the table names were replaced by their table variable.