### PR TITLE
feat: simplify approval data endpoint to return only content hashes

### DIFF
--- a/src/Collection/Collection.router.spec.ts
+++ b/src/Collection/Collection.router.spec.ts
@@ -1891,13 +1891,11 @@ describe('Collection router', () => {
               {
                 id: uuid(),
                 local_content_hash: 'Qm1abababa',
-                urn_suffix: '1',
               },
-              { id: uuid(), local_content_hash: '', urn_suffix: '2' },
+              { id: uuid(), local_content_hash: '' },
               {
                 id: uuid(),
                 local_content_hash: 'Qm3rererer',
-                urn_suffix: '',
               },
             ]
 
@@ -1928,7 +1926,7 @@ describe('Collection router', () => {
                     eth_address: wallet.address,
                   },
                   error:
-                    'Item missing the urn_suffix or local_content_hash needed to approve it',
+                    'Item missing the local_content_hash needed to approve it',
                 })
               })
           })
@@ -1940,17 +1938,14 @@ describe('Collection router', () => {
               {
                 id: uuid(),
                 local_content_hash: 'Qm1abababa',
-                urn_suffix: '1',
               },
               {
                 id: uuid(),
                 local_content_hash: 'Qm2bdbdbdb',
-                urn_suffix: '2',
               },
               {
                 id: uuid(),
                 local_content_hash: 'Qm3rererer',
-                urn_suffix: '3',
               },
             ]
 
@@ -1976,23 +1971,7 @@ describe('Collection router', () => {
               .then((response: any) => {
                 expect(response.body).toEqual({
                   ok: true,
-                  data: [
-                    {
-                      urn:
-                        'urn:decentraland:mumbai:collections-thirdparty:third-party-id:collection-id:1',
-                      content_hash: 'Qm1abababa',
-                    },
-                    {
-                      urn:
-                        'urn:decentraland:mumbai:collections-thirdparty:third-party-id:collection-id:2',
-                      content_hash: 'Qm2bdbdbdb',
-                    },
-                    {
-                      urn:
-                        'urn:decentraland:mumbai:collections-thirdparty:third-party-id:collection-id:3',
-                      content_hash: 'Qm3rererer',
-                    },
-                  ],
+                  data: ['Qm1abababa', 'Qm2bdbdbdb', 'Qm3rererer'],
                 })
               })
           })

--- a/src/Collection/Collection.service.ts
+++ b/src/Collection/Collection.service.ts
@@ -18,7 +18,6 @@ import {
   UnpublishedItemError,
   InconsistentItemError,
 } from '../Item/Item.errors'
-import { buildTPItemURN } from '../Item/utils'
 import { ItemCuration, ItemCurationAttributes } from '../Curation/ItemCuration'
 import { SlotUsageCheque, SlotUsageChequeAttributes } from '../SlotUsageCheque'
 import {
@@ -392,26 +391,15 @@ export class CollectionService {
       throw new UnpublishedCollectionError(id)
     }
 
-    const approvalData: ItemApprovalData[] = []
-    for (const { id, urn_suffix, local_content_hash } of dbApprovalData) {
-      if (!urn_suffix || !local_content_hash) {
+    return dbApprovalData.map((data) => {
+      if (!data.local_content_hash) {
         throw new InconsistentItemError(
-          id,
-          'Item missing the urn_suffix or local_content_hash needed to approve it'
+          data.id,
+          'Item missing the local_content_hash needed to approve it'
         )
       }
-
-      approvalData.push({
-        urn: buildTPItemURN(
-          collection.third_party_id,
-          collection.urn_suffix,
-          urn_suffix
-        ),
-        content_hash: local_content_hash,
-      })
-    }
-
-    return approvalData
+      return data.local_content_hash
+    })
   }
 
   /**

--- a/src/Item/Item.model.ts
+++ b/src/Item/Item.model.ts
@@ -16,7 +16,7 @@ export class Item extends Model<ItemAttributes> {
 
   static findDBApprovalDataByCollectionId(collectionId: string) {
     return this.query<DBItemApprovalData>(SQL`
-      SELECT items.id, items.urn_suffix, item_curations.local_content_hash
+      SELECT items.id, item_curations.local_content_hash
         FROM ${raw(this.tableName)} items
         JOIN ${raw(
           ItemCuration.tableName

--- a/src/Item/Item.types.ts
+++ b/src/Item/Item.types.ts
@@ -63,9 +63,9 @@ export type FullItem = Omit<ItemAttributes, 'urn_suffix'> & {
 
 export type DBItemApprovalData = Pick<
   ItemAttributes,
-  'id' | 'urn_suffix' | 'local_content_hash'
+  'id' | 'local_content_hash'
 >
-export type ItemApprovalData = Pick<FullItem, 'urn'> & { content_hash: string }
+export type ItemApprovalData = string // content_hash
 
 type BaseWearableEntityMetadata = Omit<
   Wearable,


### PR DESCRIPTION
Related to https://github.com/decentraland/content-hash-tree/commit/b27c7ff451ccd2ab9913ac8e0bbf257f3d8408a9

Needed for:
- https://github.com/decentraland/builder/issues/1846
- https://github.com/decentraland/builder/issues/1847

It changes the 
`/collections/:id/approvalData` endpoint to only return contentHashes instead of the `{ content_hash; urn }` object