### PR TITLE
chore: Extend NFT type

### DIFF
--- a/src/NFT/NFT.router.spec.ts
+++ b/src/NFT/NFT.router.spec.ts
@@ -3,6 +3,7 @@ import { STATUS_CODES } from '../common/HTTPError'
 import { app } from '../server'
 import { NFTService } from './NFT.service'
 import { NFT } from './NFT.types'
+import { getMockNFT } from './utils'
 
 jest.mock('./NFT.service')
 
@@ -243,92 +244,7 @@ describe('when getting a single nft', () => {
   })
 
   it('should return an nft', async () => {
-    const nft: NFT = {
-      backgroundColor: 'background_color',
-      contract: {
-        description: 'description',
-        externalLink: 'external_link',
-        imageUrl: 'image_url',
-        name: 'name',
-        symbol: 'symbol',
-      },
-      description: 'description',
-      externalLink: 'external_link',
-      imageOriginalUrl: 'image_original_url',
-      imagePreviewUrl: 'image_preview_url',
-      imageThumbnailUrl: 'image_thumbnail_url',
-      imageUrl: 'image_url',
-      lastSale: {
-        eventType: 'event_type',
-        paymentToken: {
-          symbol: 'symbol',
-        },
-        quantity: 'quantity',
-        totalPrice: 'total_price',
-      },
-      name: 'name',
-      orders: [
-        {
-          maker: {
-            address: 'address',
-            config: 'config',
-            profileImageUrl: 'profile_img_url',
-            user: {
-              username: 'username',
-            },
-          },
-          currentPrice: 'current_price',
-          paymentTokenContract: {
-            symbol: 'symbol',
-          },
-        },
-      ],
-      owner: {
-        address: 'address',
-        config: 'config',
-        profileImageUrl: 'profile_img_url',
-        user: {
-          username: 'username',
-        },
-      },
-      sellOrders: [
-        {
-          maker: {
-            address: 'address',
-            config: 'config',
-            profileImageUrl: 'profile_img_url',
-            user: {
-              username: 'username',
-            },
-          },
-          currentPrice: 'current_price',
-          paymentTokenContract: {
-            symbol: 'symbol',
-          },
-        },
-      ],
-      tokenId: 'token_id',
-      topOwnerships: [
-        {
-          owner: {
-            address: 'address',
-            config: 'config',
-            profileImageUrl: 'profile_img_url',
-            user: {
-              username: 'username',
-            },
-          },
-          quantity: 'quantity',
-        },
-      ],
-      traits: [
-        {
-          displayType: 'display_type',
-          type: 'trait_type',
-          value: 'value',
-        },
-      ],
-    }
+    const nft: NFT = getMockNFT()
 
     mockNFTService.prototype.getNFT.mockResolvedValueOnce(nft)
 

--- a/src/NFT/NFT.router.spec.ts
+++ b/src/NFT/NFT.router.spec.ts
@@ -252,7 +252,11 @@ describe('when getting a single nft', () => {
         name: 'name',
         symbol: 'symbol',
       },
+      description: 'description',
       externalLink: 'external_link',
+      imageOriginalUrl: 'image_original_url',
+      imagePreviewUrl: 'image_preview_url',
+      imageThumbnailUrl: 'image_thumbnail_url',
       imageUrl: 'image_url',
       lastSale: {
         eventType: 'event_type',
@@ -263,15 +267,60 @@ describe('when getting a single nft', () => {
         totalPrice: 'total_price',
       },
       name: 'name',
+      orders: [
+        {
+          maker: {
+            address: 'address',
+            config: 'config',
+            profileImageUrl: 'profile_img_url',
+            user: {
+              username: 'username',
+            },
+          },
+          currentPrice: 'current_price',
+          paymentTokenContract: {
+            symbol: 'symbol',
+          },
+        },
+      ],
       owner: {
         address: 'address',
         config: 'config',
-        profileImageUrl: 'profile_image_url',
+        profileImageUrl: 'profile_img_url',
         user: {
           username: 'username',
         },
       },
+      sellOrders: [
+        {
+          maker: {
+            address: 'address',
+            config: 'config',
+            profileImageUrl: 'profile_img_url',
+            user: {
+              username: 'username',
+            },
+          },
+          currentPrice: 'current_price',
+          paymentTokenContract: {
+            symbol: 'symbol',
+          },
+        },
+      ],
       tokenId: 'token_id',
+      topOwnerships: [
+        {
+          owner: {
+            address: 'address',
+            config: 'config',
+            profileImageUrl: 'profile_img_url',
+            user: {
+              username: 'username',
+            },
+          },
+          quantity: 'quantity',
+        },
+      ],
       traits: [
         {
           displayType: 'display_type',

--- a/src/NFT/NFT.service.spec.ts
+++ b/src/NFT/NFT.service.spec.ts
@@ -53,11 +53,39 @@ beforeEach(() => {
     image_url: 'image_url',
     last_sale: {
       event_type: 'event_type',
-      payment_token: {
-        symbol: 'symbol',
-      },
-      quantity: 'quantity',
+      event_timestamp: 'event_timestamp',
       total_price: 'total_price',
+      quantity: 'quantity',
+      payment_token: {
+        id: 100,
+        symbol: 'symbol',
+        address: 'address',
+        image_url: 'image_url',
+        name: 'name',
+        decimals: 18,
+        eth_price: 'eth_price',
+        usd_price: 'usd_price',
+      },
+      transaction: {
+        id: 100,
+        from_account: {
+          address: 'address',
+          config: 'config',
+          profile_img_url: 'profile_img_url',
+          user: {
+            username: 'username',
+          },
+        },
+        to_account: {
+          address: 'address',
+          config: 'config',
+          profile_img_url: 'profile_img_url',
+          user: {
+            username: 'username',
+          },
+        },
+        transaction_hash: 'transaction_hash',
+      },
     },
     name: 'name',
     orders: [
@@ -72,7 +100,14 @@ beforeEach(() => {
         },
         current_price: 'current_price',
         payment_token_contract: {
+          id: 100,
           symbol: 'symbol',
+          address: 'address',
+          image_url: 'image_url',
+          name: 'name',
+          decimals: 18,
+          eth_price: 'eth_price',
+          usd_price: 'usd_price',
         },
       },
     ],
@@ -96,7 +131,14 @@ beforeEach(() => {
         },
         current_price: 'current_price',
         payment_token_contract: {
+          id: 100,
           symbol: 'symbol',
+          address: 'address',
+          image_url: 'image_url',
+          name: 'name',
+          decimals: 18,
+          eth_price: 'eth_price',
+          usd_price: 'usd_price',
         },
       },
     ],

--- a/src/NFT/NFT.service.spec.ts
+++ b/src/NFT/NFT.service.spec.ts
@@ -31,26 +31,20 @@ beforeEach(() => {
   }
 
   mockExternalNFT = {
-    token_id: 'token_id',
-    image_url: 'image_url',
     background_color: 'background_color',
-    name: 'name',
-    external_link: 'external_link',
-    owner: {
-      address: 'address',
-      config: 'config',
-      profile_image_url: 'profile_image_url',
-      user: {
-        username: 'username',
-      },
+    asset_contract: {
+      description: 'description',
+      external_link: 'external_link',
+      image_url: 'image_url',
+      name: 'name',
+      symbol: 'symbol',
     },
-    traits: [
-      {
-        display_type: 'display_type',
-        trait_type: 'trait_type',
-        value: 'value',
-      },
-    ],
+    description: 'description',
+    external_link: 'external_link',
+    image_original_url: 'image_original_url',
+    image_preview_url: 'image_preview_url',
+    image_thumbnail_url: 'image_thumbnail_url',
+    image_url: 'image_url',
     last_sale: {
       event_type: 'event_type',
       payment_token: {
@@ -59,13 +53,68 @@ beforeEach(() => {
       quantity: 'quantity',
       total_price: 'total_price',
     },
-    asset_contract: {
-      description: 'description',
-      external_link: 'external_link',
-      image_url: 'image_url',
-      name: 'name',
-      symbol: 'symbol',
+    name: 'name',
+    orders: [
+      {
+        maker: {
+          address: 'address',
+          config: 'config',
+          profile_img_url: 'profile_img_url',
+          user: {
+            username: 'username',
+          },
+        },
+        current_price: 'current_price',
+        payment_token_contract: {
+          symbol: 'symbol',
+        },
+      },
+    ],
+    owner: {
+      address: 'address',
+      config: 'config',
+      profile_img_url: 'profile_img_url',
+      user: {
+        username: 'username',
+      },
     },
+    sell_orders: [
+      {
+        maker: {
+          address: 'address',
+          config: 'config',
+          profile_img_url: 'profile_img_url',
+          user: {
+            username: 'username',
+          },
+        },
+        current_price: 'current_price',
+        payment_token_contract: {
+          symbol: 'symbol',
+        },
+      },
+    ],
+    token_id: 'token_id',
+    top_ownerships: [
+      {
+        owner: {
+          address: 'address',
+          config: 'config',
+          profile_img_url: 'profile_img_url',
+          user: {
+            username: 'username',
+          },
+        },
+        quantity: 'quantity',
+      },
+    ],
+    traits: [
+      {
+        display_type: 'display_type',
+        trait_type: 'trait_type',
+        value: 'value',
+      },
+    ],
   }
 
   mockMappedExternalNFT = {
@@ -77,7 +126,11 @@ beforeEach(() => {
       name: 'name',
       symbol: 'symbol',
     },
+    description: 'description',
     externalLink: 'external_link',
+    imageOriginalUrl: 'image_original_url',
+    imagePreviewUrl: 'image_preview_url',
+    imageThumbnailUrl: 'image_thumbnail_url',
     imageUrl: 'image_url',
     lastSale: {
       eventType: 'event_type',
@@ -88,15 +141,60 @@ beforeEach(() => {
       totalPrice: 'total_price',
     },
     name: 'name',
+    orders: [
+      {
+        maker: {
+          address: 'address',
+          config: 'config',
+          profileImageUrl: 'profile_img_url',
+          user: {
+            username: 'username',
+          },
+        },
+        currentPrice: 'current_price',
+        paymentTokenContract: {
+          symbol: 'symbol',
+        },
+      },
+    ],
     owner: {
       address: 'address',
       config: 'config',
-      profileImageUrl: 'profile_image_url',
+      profileImageUrl: 'profile_img_url',
       user: {
         username: 'username',
       },
     },
+    sellOrders: [
+      {
+        maker: {
+          address: 'address',
+          config: 'config',
+          profileImageUrl: 'profile_img_url',
+          user: {
+            username: 'username',
+          },
+        },
+        currentPrice: 'current_price',
+        paymentTokenContract: {
+          symbol: 'symbol',
+        },
+      },
+    ],
     tokenId: 'token_id',
+    topOwnerships: [
+      {
+        owner: {
+          address: 'address',
+          config: 'config',
+          profileImageUrl: 'profile_img_url',
+          user: {
+            username: 'username',
+          },
+        },
+        quantity: 'quantity',
+      },
+    ],
     traits: [
       {
         displayType: 'display_type',

--- a/src/NFT/NFT.service.spec.ts
+++ b/src/NFT/NFT.service.spec.ts
@@ -2,6 +2,7 @@ import { env } from 'decentraland-commons'
 import fetch, { Response } from 'node-fetch'
 import { NFTService } from './NFT.service'
 import { NFT } from './NFT.types'
+import { getMockNFT } from './utils'
 
 jest.mock('node-fetch')
 jest.mock('decentraland-commons')
@@ -33,11 +34,16 @@ beforeEach(() => {
   mockExternalNFT = {
     background_color: 'background_color',
     asset_contract: {
+      address: 'address',
+      created_date: 'created_date',
+      name: 'name',
+      nft_version: 'nft_version',
+      schema_name: 'schema_name',
+      symbol: 'symbol',
+      total_supply: 'total_supply',
       description: 'description',
       external_link: 'external_link',
       image_url: 'image_url',
-      name: 'name',
-      symbol: 'symbol',
     },
     description: 'description',
     external_link: 'external_link',
@@ -117,92 +123,7 @@ beforeEach(() => {
     ],
   }
 
-  mockMappedExternalNFT = {
-    backgroundColor: 'background_color',
-    contract: {
-      description: 'description',
-      externalLink: 'external_link',
-      imageUrl: 'image_url',
-      name: 'name',
-      symbol: 'symbol',
-    },
-    description: 'description',
-    externalLink: 'external_link',
-    imageOriginalUrl: 'image_original_url',
-    imagePreviewUrl: 'image_preview_url',
-    imageThumbnailUrl: 'image_thumbnail_url',
-    imageUrl: 'image_url',
-    lastSale: {
-      eventType: 'event_type',
-      paymentToken: {
-        symbol: 'symbol',
-      },
-      quantity: 'quantity',
-      totalPrice: 'total_price',
-    },
-    name: 'name',
-    orders: [
-      {
-        maker: {
-          address: 'address',
-          config: 'config',
-          profileImageUrl: 'profile_img_url',
-          user: {
-            username: 'username',
-          },
-        },
-        currentPrice: 'current_price',
-        paymentTokenContract: {
-          symbol: 'symbol',
-        },
-      },
-    ],
-    owner: {
-      address: 'address',
-      config: 'config',
-      profileImageUrl: 'profile_img_url',
-      user: {
-        username: 'username',
-      },
-    },
-    sellOrders: [
-      {
-        maker: {
-          address: 'address',
-          config: 'config',
-          profileImageUrl: 'profile_img_url',
-          user: {
-            username: 'username',
-          },
-        },
-        currentPrice: 'current_price',
-        paymentTokenContract: {
-          symbol: 'symbol',
-        },
-      },
-    ],
-    tokenId: 'token_id',
-    topOwnerships: [
-      {
-        owner: {
-          address: 'address',
-          config: 'config',
-          profileImageUrl: 'profile_img_url',
-          user: {
-            username: 'username',
-          },
-        },
-        quantity: 'quantity',
-      },
-    ],
-    traits: [
-      {
-        displayType: 'display_type',
-        type: 'trait_type',
-        value: 'value',
-      },
-    ],
-  }
+  mockMappedExternalNFT = getMockNFT()
 
   jest.clearAllMocks()
 })

--- a/src/NFT/NFT.service.ts
+++ b/src/NFT/NFT.service.ts
@@ -117,8 +117,6 @@ export class NFTService {
 
     const externalNFT = await response.json()
 
-    console.log(externalNFT)
-
     return this.mapExternalNFT(externalNFT)
   }
 
@@ -181,7 +179,7 @@ export class NFTService {
       traits: (ext.traits as any[]).map(mapTrait),
       lastSale: ext.last_sale ? mapLastSale(ext.last_sale) : null,
       sellOrders: ext.sell_orders
-        ? (ext.sell_order as any[]).map(mapOrder)
+        ? (ext.sell_orders as any[]).map(mapOrder)
         : null,
       orders: ext.orders ? (ext.orders as any[]).map(mapOrder) : null,
       topOwnerships: ext.top_ownerships

--- a/src/NFT/NFT.service.ts
+++ b/src/NFT/NFT.service.ts
@@ -1,6 +1,18 @@
 import fetch from 'node-fetch'
 import { env } from 'decentraland-commons'
-import { GetNFTParams, GetNFTsParams, GetNFTsResponse, NFT } from './NFT.types'
+import {
+  GetNFTParams,
+  GetNFTsParams,
+  GetNFTsResponse,
+  NFT,
+  NFTAccount,
+  NFTContract,
+  NFTLastSale,
+  NFTOrder,
+  NFTOwnership,
+  NFTToken,
+  NFTTrait,
+} from './NFT.types'
 
 export class NFTService {
   private readonly OPEN_SEA_URL: string
@@ -121,45 +133,50 @@ export class NFTService {
   }
 
   private mapExternalNFT(ext: any): NFT {
-    const mapAccount = (account: any) => ({
+    const mapAccount = (account: any): NFTAccount => ({
       user: account.user ? { username: account.user.username } : null,
       profileImageUrl: account.profile_img_url,
       address: account.address,
       config: account.config,
     })
 
-    const mapToken = (token: any) => ({
+    const mapToken = (token: any): NFTToken => ({
       symbol: token.symbol,
     })
 
-    const mapContract = (contract: any) => ({
+    const mapContract = (contract: any): NFTContract => ({
+      address: contract.address,
+      createdDate: contract.created_date,
       name: contract.name,
+      nftVersion: contract.nft_version,
+      schemaName: contract.schema_name,
       symbol: contract.symbol,
-      imageUrl: contract.image_url,
+      totalSupply: contract.total_supply,
       description: contract.description,
       externalLink: contract.external_link,
+      imageUrl: contract.image_url,
     })
 
-    const mapTrait = (trait: any) => ({
+    const mapTrait = (trait: any): NFTTrait => ({
       type: trait.trait_type,
       value: trait.value,
       displayType: trait.display_type,
     })
 
-    const mapLastSale = (lastSale: any) => ({
+    const mapLastSale = (lastSale: any): NFTLastSale => ({
       eventType: lastSale.event_type,
       totalPrice: lastSale.total_price,
       quantity: lastSale.quantity,
       paymentToken: mapToken(lastSale.payment_token),
     })
 
-    const mapOrder = (order: any) => ({
+    const mapOrder = (order: any): NFTOrder => ({
       maker: mapAccount(order.maker),
       currentPrice: order.current_price,
       paymentTokenContract: mapToken(order.payment_token_contract),
     })
 
-    const mapOwnership = (ownership: any) => ({
+    const mapOwnership = (ownership: any): NFTOwnership => ({
       owner: mapAccount(ownership.owner),
       quantity: ownership.quantity,
     })

--- a/src/NFT/NFT.service.ts
+++ b/src/NFT/NFT.service.ts
@@ -7,11 +7,12 @@ import {
   NFT,
   NFTAccount,
   NFTContract,
-  NFTLastSale,
+  NFTSale,
   NFTOrder,
   NFTOwnership,
   NFTToken,
   NFTTrait,
+  NFTTransaction,
 } from './NFT.types'
 
 export class NFTService {
@@ -141,7 +142,14 @@ export class NFTService {
     })
 
     const mapToken = (token: any): NFTToken => ({
+      id: token.id,
       symbol: token.symbol,
+      address: token.address,
+      imageUrl: token.image_url,
+      name: token.name,
+      decimals: token.decimals,
+      ethPrice: token.eth_price,
+      usdPrice: token.usd_price,
     })
 
     const mapContract = (contract: any): NFTContract => ({
@@ -163,11 +171,20 @@ export class NFTService {
       displayType: trait.display_type,
     })
 
-    const mapLastSale = (lastSale: any): NFTLastSale => ({
-      eventType: lastSale.event_type,
-      totalPrice: lastSale.total_price,
-      quantity: lastSale.quantity,
-      paymentToken: mapToken(lastSale.payment_token),
+    const mapTransaction = (transaction: any): NFTTransaction => ({
+      id: transaction.id,
+      fromAccount: mapAccount(transaction.from_account),
+      toAccount: mapAccount(transaction.to_account),
+      transactionHash: transaction.transaction_hash,
+    })
+
+    const mapSale = (sale: any): NFTSale => ({
+      eventType: sale.event_type,
+      eventTimestamp: sale.event_timestamp,
+      totalPrice: sale.total_price,
+      quantity: sale.quantity,
+      paymentToken: mapToken(sale.payment_token),
+      transaction: mapTransaction(sale.transaction),
     })
 
     const mapOrder = (order: any): NFTOrder => ({
@@ -194,7 +211,7 @@ export class NFTService {
       owner: mapAccount(ext.owner),
       contract: mapContract(ext.asset_contract),
       traits: (ext.traits as any[]).map(mapTrait),
-      lastSale: ext.last_sale ? mapLastSale(ext.last_sale) : null,
+      lastSale: ext.last_sale ? mapSale(ext.last_sale) : null,
       sellOrders: ext.sell_orders
         ? (ext.sell_orders as any[]).map(mapOrder)
         : null,

--- a/src/NFT/NFT.types.ts
+++ b/src/NFT/NFT.types.ts
@@ -1,3 +1,4 @@
+// NFT Entity
 export type NFT = {
   tokenId: string
   backgroundColor: string | null
@@ -9,24 +10,9 @@ export type NFT = {
   description: string | null
   externalLink: string | null
   owner: NFTAccount
-  contract: {
-    name: string
-    symbol: string
-    imageUrl: string | null
-    description: string
-    externalLink: string | null
-  }
-  traits: {
-    type: string
-    value: string | number
-    displayType: string | null
-  }[]
-  lastSale: {
-    eventType: string
-    totalPrice: string
-    quantity: string
-    paymentToken: NFTToken
-  } | null
+  contract: NFTContract
+  traits: NFTTrait[]
+  lastSale: NFTLastSale | null
   sellOrders: NFTOrder[] | null
   orders: NFTOrder[] | null
   topOwnerships: NFTOwnership[] | null
@@ -39,14 +25,31 @@ type NFTAccount = {
   config: string
 }
 
+type NFTContract = {
+  name: string
+  symbol: string
+  imageUrl: string | null
+  description: string
+  externalLink: string | null
+}
+
+type NFTTrait = {
+  type: string
+  value: string | number
+  displayType: string | null
+}
+
+type NFTLastSale = {
+  eventType: string
+  totalPrice: string
+  quantity: string
+  paymentToken: NFTToken
+}
+
 type NFTOrder = {
   maker: NFTAccount
   currentPrice: string
   paymentTokenContract: NFTToken
-}
-
-type NFTToken = {
-  symbol: string
 }
 
 type NFTOwnership = {
@@ -54,6 +57,11 @@ type NFTOwnership = {
   quantity: string
 }
 
+type NFTToken = {
+  symbol: string
+}
+
+// Service types
 export type GetNFTsParams = {
   owner?: string
   first?: number

--- a/src/NFT/NFT.types.ts
+++ b/src/NFT/NFT.types.ts
@@ -3,8 +3,8 @@ export type NFT = {
   tokenId: string
   backgroundColor: string | null
   imageUrl: string
-  imagePreviewUrl: string
-  imageThumbnailUrl: string
+  imagePreviewUrl: string | null
+  imageThumbnailUrl: string | null
   imageOriginalUrl: string | null
   name: string | null
   description: string | null
@@ -18,46 +18,51 @@ export type NFT = {
   topOwnerships: NFTOwnership[] | null
 }
 
-type NFTAccount = {
+export type NFTAccount = {
   user: { username: string } | null
   profileImageUrl: string
   address: string
   config: string
 }
 
-type NFTContract = {
+export type NFTContract = {
+  address: string
+  createdDate: string
   name: string
+  nftVersion: string | null
+  schemaName: string
   symbol: string
-  imageUrl: string | null
+  totalSupply: string | null
   description: string
   externalLink: string | null
+  imageUrl: string | null
 }
 
-type NFTTrait = {
+export type NFTTrait = {
   type: string
   value: string | number
   displayType: string | null
 }
 
-type NFTLastSale = {
+export type NFTLastSale = {
   eventType: string
   totalPrice: string
   quantity: string
   paymentToken: NFTToken
 }
 
-type NFTOrder = {
+export type NFTOrder = {
   maker: NFTAccount
   currentPrice: string
   paymentTokenContract: NFTToken
 }
 
-type NFTOwnership = {
+export type NFTOwnership = {
   owner: NFTAccount
   quantity: string
 }
 
-type NFTToken = {
+export type NFTToken = {
   symbol: string
 }
 

--- a/src/NFT/NFT.types.ts
+++ b/src/NFT/NFT.types.ts
@@ -12,7 +12,7 @@ export type NFT = {
   owner: NFTAccount
   contract: NFTContract
   traits: NFTTrait[]
-  lastSale: NFTLastSale | null
+  lastSale: NFTSale | null
   sellOrders: NFTOrder[] | null
   orders: NFTOrder[] | null
   topOwnerships: NFTOwnership[] | null
@@ -44,11 +44,13 @@ export type NFTTrait = {
   displayType: string | null
 }
 
-export type NFTLastSale = {
+export type NFTSale = {
   eventType: string
+  eventTimestamp: string
   totalPrice: string
   quantity: string
   paymentToken: NFTToken
+  transaction: NFTTransaction
 }
 
 export type NFTOrder = {
@@ -63,7 +65,21 @@ export type NFTOwnership = {
 }
 
 export type NFTToken = {
+  id: number
   symbol: string
+  address: string
+  imageUrl: string
+  name: string
+  decimals: number
+  ethPrice: string
+  usdPrice: string
+}
+
+export type NFTTransaction = {
+  id: number
+  fromAccount: NFTAccount
+  toAccount: NFTAccount
+  transactionHash: string
 }
 
 // Service types

--- a/src/NFT/NFT.types.ts
+++ b/src/NFT/NFT.types.ts
@@ -1,37 +1,57 @@
 export type NFT = {
   tokenId: string
+  backgroundColor: string | null
   imageUrl: string
-  backgroundColor: string
-  name: string
-  externalLink: string
-  owner: {
-    user: {
-      username: string
-    }
-    profileImageUrl: string
-    address: string
-    config: string
-  }
+  imagePreviewUrl: string
+  imageThumbnailUrl: string
+  imageOriginalUrl: string | null
+  name: string | null
+  description: string | null
+  externalLink: string | null
+  owner: NFTAccount
   contract: {
     name: string
     symbol: string
-    imageUrl: string
+    imageUrl: string | null
     description: string
-    externalLink: string
+    externalLink: string | null
   }
   traits: {
     type: string
     value: string | number
-    displayType: string
+    displayType: string | null
   }[]
   lastSale: {
     eventType: string
     totalPrice: string
     quantity: string
-    paymentToken: {
-      symbol: string
-    }
+    paymentToken: NFTToken
   } | null
+  sellOrders: NFTOrder[] | null
+  orders: NFTOrder[] | null
+  topOwnerships: NFTOwnership[] | null
+}
+
+type NFTAccount = {
+  user: { username: string } | null
+  profileImageUrl: string
+  address: string
+  config: string
+}
+
+type NFTOrder = {
+  maker: NFTAccount
+  currentPrice: string
+  paymentTokenContract: NFTToken
+}
+
+type NFTToken = {
+  symbol: string
+}
+
+type NFTOwnership = {
+  owner: NFTAccount
+  quantity: string
 }
 
 export type GetNFTsParams = {

--- a/src/NFT/utils.ts
+++ b/src/NFT/utils.ts
@@ -1,0 +1,93 @@
+import { NFT } from './NFT.types'
+
+export const getMockNFT = (): NFT => ({
+  backgroundColor: 'background_color',
+  contract: {
+    address: 'address',
+    createdDate: 'created_date',
+    name: 'name',
+    nftVersion: 'nft_version',
+    schemaName: 'schema_name',
+    symbol: 'symbol',
+    totalSupply: 'total_supply',
+    description: 'description',
+    externalLink: 'external_link',
+    imageUrl: 'image_url',
+  },
+  description: 'description',
+  externalLink: 'external_link',
+  imageOriginalUrl: 'image_original_url',
+  imagePreviewUrl: 'image_preview_url',
+  imageThumbnailUrl: 'image_thumbnail_url',
+  imageUrl: 'image_url',
+  lastSale: {
+    eventType: 'event_type',
+    paymentToken: {
+      symbol: 'symbol',
+    },
+    quantity: 'quantity',
+    totalPrice: 'total_price',
+  },
+  name: 'name',
+  orders: [
+    {
+      maker: {
+        address: 'address',
+        config: 'config',
+        profileImageUrl: 'profile_img_url',
+        user: {
+          username: 'username',
+        },
+      },
+      currentPrice: 'current_price',
+      paymentTokenContract: {
+        symbol: 'symbol',
+      },
+    },
+  ],
+  owner: {
+    address: 'address',
+    config: 'config',
+    profileImageUrl: 'profile_img_url',
+    user: {
+      username: 'username',
+    },
+  },
+  sellOrders: [
+    {
+      maker: {
+        address: 'address',
+        config: 'config',
+        profileImageUrl: 'profile_img_url',
+        user: {
+          username: 'username',
+        },
+      },
+      currentPrice: 'current_price',
+      paymentTokenContract: {
+        symbol: 'symbol',
+      },
+    },
+  ],
+  tokenId: 'token_id',
+  topOwnerships: [
+    {
+      owner: {
+        address: 'address',
+        config: 'config',
+        profileImageUrl: 'profile_img_url',
+        user: {
+          username: 'username',
+        },
+      },
+      quantity: 'quantity',
+    },
+  ],
+  traits: [
+    {
+      displayType: 'display_type',
+      type: 'trait_type',
+      value: 'value',
+    },
+  ],
+})

--- a/src/NFT/utils.ts
+++ b/src/NFT/utils.ts
@@ -22,11 +22,39 @@ export const getMockNFT = (): NFT => ({
   imageUrl: 'image_url',
   lastSale: {
     eventType: 'event_type',
-    paymentToken: {
-      symbol: 'symbol',
-    },
-    quantity: 'quantity',
+    eventTimestamp: 'event_timestamp',
     totalPrice: 'total_price',
+    quantity: 'quantity',
+    paymentToken: {
+      id: 100,
+      symbol: 'symbol',
+      address: 'address',
+      imageUrl: 'image_url',
+      name: 'name',
+      decimals: 18,
+      ethPrice: 'eth_price',
+      usdPrice: 'usd_price',
+    },
+    transaction: {
+      id: 100,
+      fromAccount: {
+        address: 'address',
+        config: 'config',
+        profileImageUrl: 'profile_img_url',
+        user: {
+          username: 'username',
+        },
+      },
+      toAccount: {
+        address: 'address',
+        config: 'config',
+        profileImageUrl: 'profile_img_url',
+        user: {
+          username: 'username',
+        },
+      },
+      transactionHash: 'transaction_hash',
+    },
   },
   name: 'name',
   orders: [
@@ -41,7 +69,14 @@ export const getMockNFT = (): NFT => ({
       },
       currentPrice: 'current_price',
       paymentTokenContract: {
+        id: 100,
         symbol: 'symbol',
+        address: 'address',
+        imageUrl: 'image_url',
+        name: 'name',
+        decimals: 18,
+        ethPrice: 'eth_price',
+        usdPrice: 'usd_price',
       },
     },
   ],
@@ -65,7 +100,14 @@ export const getMockNFT = (): NFT => ({
       },
       currentPrice: 'current_price',
       paymentTokenContract: {
+        id: 100,
         symbol: 'symbol',
+        address: 'address',
+        imageUrl: 'image_url',
+        name: 'name',
+        decimals: 18,
+        ethPrice: 'eth_price',
+        usdPrice: 'usd_price',
       },
     },
   ],


### PR DESCRIPTION
In order to cover more cases, a lot more fields have been added to the NFT type.
Based both on what is being consumed by [unity-renderer](https://github.com/decentraland/unity-renderer) with [these types](https://github.com/decentraland/unity-renderer/blob/master/unity-renderer/Assets/Scripts/MainScripts/DCL/ServiceProviders/OpenSea/Types.cs#L12) and what is being consumed by the [builder](https://github.com/decentraland/builder) in the current [asset sagas](https://github.com/decentraland/builder/blob/master/src/modules/asset/sagas.ts#L25).