### PR TITLE
fix: Use older hash for standard items

### DIFF
--- a/src/Item/Item.router.spec.ts
+++ b/src/Item/Item.router.spec.ts
@@ -1334,7 +1334,7 @@ describe('Item router', () => {
               data: {
                 ...Bridge.toFullItem(dbItem),
                 local_content_hash:
-                  'bafkreiejcahiwp257urwn5u2wn5os3mcjhvid6eqhmok7tezzhvdm5njqy',
+                  'QmXZgmKEUkoaq4rM5n24KA9FmNUCRyuAAjvDfVpgLWCLhb',
                 eth_address: wallet.address,
                 created_at: dbItem.created_at.toISOString(),
                 updated_at: currentDate.toISOString(),

--- a/src/Item/hashes.spec.ts
+++ b/src/Item/hashes.spec.ts
@@ -60,9 +60,7 @@ describe('when calculating the hashes of a standard item', () => {
   it("should return the hash of the item's entity", () => {
     return expect(
       calculateItemContentHash(dbItem, dbCollection)
-    ).resolves.toEqual(
-      'bafkreihtcjnfcahy3nomnhxiuyjyzj2fxzy3eab7ctmxl237nf2vsoqkmu'
-    )
+    ).resolves.toEqual('QmehW1ccHcvdKp8NNhrr6PdxEDHGYa9j6xmu9Bojg8jcjN')
   })
 })
 

--- a/src/Item/hashes.ts
+++ b/src/Item/hashes.ts
@@ -1,4 +1,7 @@
-import { calculateMultipleHashesADR32, keccak256Hash } from '@dcl/hashing'
+import {
+  calculateMultipleHashesADR32LegacyQmHash,
+  keccak256Hash,
+} from '@dcl/hashing'
 import { CollectionAttributes } from '../Collection'
 import { getDecentralandItemURN, isTPCollection } from '../utils/urn'
 import {
@@ -96,7 +99,10 @@ async function calculateStandardItemContentHash(
     file,
     hash: item.contents[file],
   }))
-  const { hash } = await calculateMultipleHashesADR32(content, metadata)
+  const { hash } = await calculateMultipleHashesADR32LegacyQmHash(
+    content,
+    metadata
+  )
 
   return hash
 }


### PR DESCRIPTION
Change the item entity hashing method to use the older method until we switch to the new one.