### PR TITLE
fix: Hash computation over older item

### DIFF
--- a/src/Item/Item.service.ts
+++ b/src/Item/Item.service.ts
@@ -360,7 +360,6 @@ export class ItemService {
     dbCollection: CollectionAttributes | undefined,
     eth_address: string
   ): Promise<FullItem> {
-    let contentHash = null
     const canUpsert = await new Ownable(Item).canUpsert(item.id, eth_address)
     if (!canUpsert) {
       throw new UnauthorizedToUpsertError(item.id, eth_address)
@@ -420,9 +419,6 @@ export class ItemService {
             ItemAction.RARITY_UPDATE
           )
         }
-
-        // Compute the content hash of the item to later store it in the DB
-        contentHash = await calculateItemContentHash(dbItem, dbCollection!)
       } else if (this.collectionService.isLockActive(dbCollection.lock)) {
         throw new CollectionForItemLockedError(item.id, ItemAction.UPSERT)
       }
@@ -433,7 +429,13 @@ export class ItemService {
       eth_address,
     })
 
-    attributes.local_content_hash = contentHash
+    attributes.blockchain_item_id = dbItem ? dbItem.blockchain_item_id : null
+
+    // Compute the content hash of the item to later store it in the DB
+    attributes.local_content_hash =
+      attributes?.blockchain_item_id && dbCollection?.contract_address
+        ? await calculateItemContentHash(attributes, dbCollection!)
+        : null
 
     const upsertedItem: ItemAttributes = await Item.upsert(attributes)
     return Bridge.toFullItem(upsertedItem, dbCollection)

--- a/src/Item/Item.service.ts
+++ b/src/Item/Item.service.ts
@@ -9,6 +9,7 @@ import { Bridge } from '../ethereum/api/Bridge'
 import { collectionAPI } from '../ethereum/api/collection'
 import { peerAPI } from '../ethereum/api/peer'
 import { thirdPartyAPI } from '../ethereum/api/thirdParty'
+import { isStandardItemPublished } from '../ItemAndCollection/utils'
 import { Ownable } from '../Ownable'
 import { buildModelDates } from '../utils/dates'
 import {
@@ -433,8 +434,8 @@ export class ItemService {
 
     // Compute the content hash of the item to later store it in the DB
     attributes.local_content_hash =
-      attributes?.blockchain_item_id && dbCollection?.contract_address
-        ? await calculateItemContentHash(attributes, dbCollection!)
+      dbCollection && isStandardItemPublished(attributes, dbCollection)
+        ? await calculateItemContentHash(attributes, dbCollection)
         : null
 
     const upsertedItem: ItemAttributes = await Item.upsert(attributes)

--- a/src/Item/hashes.ts
+++ b/src/Item/hashes.ts
@@ -3,6 +3,7 @@ import {
   keccak256Hash,
 } from '@dcl/hashing'
 import { CollectionAttributes } from '../Collection'
+import { isStandardItemPublished } from '../ItemAndCollection/utils'
 import { getDecentralandItemURN, isTPCollection } from '../utils/urn'
 import {
   StandardWearableEntityMetadata,
@@ -18,7 +19,7 @@ export function buildStandardWearableEntityMetadata(
   item: ItemAttributes,
   collection: CollectionAttributes
 ): StandardWearableEntityMetadata {
-  if (!collection.contract_address || !item.blockchain_item_id!) {
+  if (!isStandardItemPublished(item, collection)) {
     throw new Error(
       "The item's collection must be published to build its metadata"
     )

--- a/src/ItemAndCollection/utils.spec.ts
+++ b/src/ItemAndCollection/utils.spec.ts
@@ -1,0 +1,46 @@
+import { dbCollectionMock } from '../../spec/mocks/collections'
+import { dbItemMock } from '../../spec/mocks/items'
+import { CollectionAttributes } from '../Collection/Collection.types'
+import { ItemAttributes } from '../Item/Item.types'
+import { isStandardItemPublished } from './utils'
+
+describe('when checking if an item is published', () => {
+  let item: ItemAttributes
+  let collection: CollectionAttributes
+
+  beforeEach(() => {
+    collection = { ...dbCollectionMock }
+    item = { ...dbItemMock, collection_id: dbCollectionMock.id }
+  })
+
+  describe("and the item doesn't have a blockchain item id", () => {
+    beforeEach(() => {
+      item.blockchain_item_id = null
+    })
+
+    it('should return false', () => {
+      expect(isStandardItemPublished(item, collection)).toBe(false)
+    })
+  })
+
+  describe("and the item's collection doesn't have a contract address", () => {
+    beforeEach(() => {
+      collection.contract_address = null
+    })
+
+    it('should return false', () => {
+      expect(isStandardItemPublished(item, collection)).toBe(false)
+    })
+  })
+
+  describe('and the item has a blockchain item id and the collection has a contract address', () => {
+    beforeEach(() => {
+      item.blockchain_item_id = '20'
+      collection.contract_address = '0x123'
+    })
+
+    it('should return true', () => {
+      expect(isStandardItemPublished(item, collection)).toBe(true)
+    })
+  })
+})

--- a/src/ItemAndCollection/utils.ts
+++ b/src/ItemAndCollection/utils.ts
@@ -1,0 +1,9 @@
+import { CollectionAttributes } from '../Collection/Collection.types'
+import { ItemAttributes } from '../Item/Item.types'
+
+export function isStandardItemPublished(
+  item: ItemAttributes,
+  collection: CollectionAttributes
+): boolean {
+  return !!item.blockchain_item_id && !!collection.contract_address
+}


### PR DESCRIPTION
This PR moves the computation of the `local_content_hash` of the item down below the `upsertDCLItem` method so the `local_content_hash` gets computed with the changes to the item.