### PR TITLE
feat: Add catalyst content hash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -537,9 +537,9 @@
       }
     },
     "@dcl/schemas": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-3.10.0.tgz",
-      "integrity": "sha512-MMlFQ65pfDpcnXztpowieRk/Y7m01nM0WNg1ACSlKdo0GH1JrYikDPq4VuRCP7LWMDpoWVSGRdH0fJ0YvC5TzQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-4.1.0.tgz",
+      "integrity": "sha512-NCKWoK1KtrMlsP0hRM/4Btb4+o48gpi6ZCaEyDnDLYwuCJcApXISB3qaQY/FzdKuyfx6C3MEbjeCGZbhlEIhpQ==",
       "requires": {
         "ajv": "^7.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@apollo/client": "^3.3.9",
     "@dcl/hashing": "^1.1.0",
-    "@dcl/schemas": "^3.10.0",
+    "@dcl/schemas": "^4.1.0",
     "@ethersproject/solidity": "^5.0.9",
     "@types/escape-html": "0.0.20",
     "@types/express": "^4.17.11",

--- a/spec/mocks/items.ts
+++ b/spec/mocks/items.ts
@@ -1,6 +1,6 @@
 import { constants } from 'ethers'
+import { ThirdPartyWearable } from '@dcl/schemas'
 import { v4 as uuidv4 } from 'uuid'
-import { Wearable } from '../../src/ethereum/api/peer'
 import {
   ItemFragment,
   ThirdPartyItemFragment,
@@ -19,6 +19,7 @@ import { buildTPItemURN } from '../../src/Item/utils'
 import { CollectionAttributes } from '../../src/Collection'
 import { WearableBodyShape } from '../../src/Item/wearable/types'
 import { isTPCollection } from '../../src/utils/urn'
+import { CatalystItem } from '../../src/ethereum/api/peer'
 import { dbCollectionMock, dbTPCollectionMock } from './collections'
 
 export type ResultItem = Omit<FullItem, 'created_at' | 'updated_at'> & {
@@ -29,7 +30,7 @@ export type ResultItem = Omit<FullItem, 'created_at' | 'updated_at'> & {
 export function toResultItem(
   itemAttributes: ItemAttributes,
   itemFragment?: ItemFragment,
-  catalystItem?: Wearable,
+  catalystItem?: CatalystItem,
   dbCollection?: CollectionAttributes
 ): ResultItem {
   const hasURN =
@@ -55,6 +56,7 @@ export function toResultItem(
       ? Number(itemFragment?.totalSupply)
       : 0,
     content_hash: itemFragment?.contentHash || null,
+    catalyst_content_hash: null,
   }
   delete (resultItem as Omit<typeof resultItem, 'urn_suffix'> & {
     urn_suffix: unknown
@@ -73,7 +75,8 @@ export function asResultItem(item: ItemAttributes): ResultItem {
 
 export function toResultTPItem(
   itemAttributes: ItemAttributes,
-  dbCollection?: CollectionAttributes
+  dbCollection?: CollectionAttributes,
+  catalystItem?: ThirdPartyWearable
 ): ResultItem {
   const hasURN =
     itemAttributes.urn_suffix && dbCollection && isTPCollection(dbCollection)
@@ -96,7 +99,10 @@ export function toResultTPItem(
     total_supply: 0,
     price: '0',
     beneficiary: constants.AddressZero,
-    content_hash: '',
+    content_hash: null,
+    catalyst_content_hash: catalystItem
+      ? catalystItem?.merkleProof.entityHash
+      : null,
   }
   delete (resultItem as Omit<typeof resultItem, 'urn_suffix'> & {
     urn_suffix: unknown
@@ -115,7 +121,6 @@ export const dbItemMock: ItemAttributes = {
   collection_id: dbCollectionMock.id,
   blockchain_item_id: '0',
   price: '',
-  content_hash: '',
   beneficiary: '',
   rarity: ItemRarity.COMMON,
   type: ItemType.WEARABLE,

--- a/spec/mocks/peer.ts
+++ b/spec/mocks/peer.ts
@@ -1,3 +1,11 @@
+import {
+  Rarity,
+  ThirdPartyWearable,
+  StandardWearable,
+  WearableCategory,
+  WearableRepresentation,
+  I18N,
+} from '@dcl/schemas'
 import { ItemRarity } from '../../src/Item'
 import { dbCollectionMock } from './collections'
 import {
@@ -6,28 +14,41 @@ import {
   thirdPartyItemFragmentMock,
 } from './items'
 
-export const wearableMock = {
+export const wearableMock: StandardWearable = {
   id: itemFragmentMock.urn,
   name: dbItemMock.name,
   description: dbItemMock.description,
   collectionAddress: dbCollectionMock.contract_address!,
-  rarity: ItemRarity.COMMON,
+  rarity: (ItemRarity.COMMON as unknown) as Rarity,
+  i18n: [{ code: 'en', text: dbItemMock.name }] as I18N[],
   image: '',
   thumbnail: '',
   metrics: dbItemMock.metrics,
-  contents: {},
   data: {
-    representations: [],
-    replaces: [],
-    hides: [],
+    category: WearableCategory.HAT,
+    representations: [] as WearableRepresentation[],
+    replaces: [] as WearableCategory[],
+    hides: [] as WearableCategory[],
     tags: [],
   },
-  createdAt: dbItemMock.created_at.getTime(),
-  updatedAt: dbItemMock.updated_at.getTime(),
 }
 
-export const tpWearableMock = {
+export const tpWearableMock: ThirdPartyWearable = {
   ...wearableMock,
   id: thirdPartyItemFragmentMock.urn,
-  collectionAddress: '',
+  merkleProof: {
+    proof: [],
+    index: 0,
+    hashingKeys: [
+      'id',
+      'name',
+      'description',
+      'data',
+      'image',
+      'thumbnail',
+      'metrics',
+      'contents',
+    ],
+    entityHash: 'someHash',
+  },
 }

--- a/src/Item/Item.router.spec.ts
+++ b/src/Item/Item.router.spec.ts
@@ -1,3 +1,4 @@
+import { StandardWearable, ThirdPartyWearable } from '@dcl/schemas'
 import supertest from 'supertest'
 import { v4 as uuidv4 } from 'uuid'
 import { Wallet } from 'ethers'
@@ -38,7 +39,7 @@ import { ItemCuration, ItemCurationAttributes } from '../Curation/ItemCuration'
 import { CurationStatus } from '../Curation'
 import { Collection } from '../Collection/Collection.model'
 import { collectionAPI } from '../ethereum/api/collection'
-import { peerAPI, Wearable } from '../ethereum/api/peer'
+import { CatalystItem, peerAPI } from '../ethereum/api/peer'
 import { ItemFragment } from '../ethereum/api/fragments'
 import { STATUS_CODES } from '../common/HTTPError'
 import { Bridge } from '../ethereum/api/Bridge'
@@ -69,7 +70,7 @@ jest.mock('./Item.model')
 
 function mockItemConsolidation(
   itemsAttributes: ItemAttributes[],
-  wearables: Wearable[]
+  wearables: CatalystItem[]
 ) {
   ;(Item.findByBlockchainIdsAndContractAddresses as jest.Mock).mockResolvedValueOnce(
     itemsAttributes
@@ -95,8 +96,8 @@ describe('Item router', () => {
   let resultItemNotPublished: ResultItem
   let resultTPItemNotPublished: ResultItem
   let resultTPItemPublished: ResultItem
-  let wearable: Wearable
-  let tpWearable: Wearable
+  let wearable: StandardWearable
+  let tpWearable: ThirdPartyWearable
   let itemFragment: ItemFragment
   let url: string
 
@@ -110,7 +111,6 @@ describe('Item router', () => {
     tpWearable = {
       ...tpWearableMock,
       id: thirdPartyItemFragmentMock.urn,
-      collectionAddress: '',
     }
     dbItemNotPublished = {
       ...dbItem,
@@ -130,7 +130,7 @@ describe('Item router', () => {
     }
     dbItemCuration = { ...itemCurationMock, item_id: dbTPItemPublished.id }
     resultingItem = toResultItem(dbItem, itemFragment, wearable)
-    resultingTPItem = toResultTPItem(dbTPItem, dbTPCollectionMock)
+    resultingTPItem = toResultTPItem(dbTPItem, dbTPCollectionMock, tpWearable)
     resultItemNotPublished = asResultItem(dbItemNotPublished)
     resultTPItemNotPublished = asResultItem(dbTPItemNotPublished) // no itemCuration & no catalyst, should be regular Item
     resultTPItemPublished = {
@@ -254,9 +254,6 @@ describe('Item router', () => {
       ;(ItemCuration.find as jest.Mock).mockResolvedValueOnce([dbItemCuration])
       ;(collectionAPI.fetchItems as jest.Mock).mockResolvedValueOnce([
         itemFragment,
-      ])
-      ;(thirdPartyAPI.fetchItems as jest.Mock).mockResolvedValueOnce([
-        thirdPartyItemFragmentMock,
       ])
       ;(Collection.findByIds as jest.Mock).mockResolvedValueOnce([
         dbTPCollectionMock,

--- a/src/Item/Item.service.ts
+++ b/src/Item/Item.service.ts
@@ -1,3 +1,4 @@
+import { StandardWearable, ThirdPartyWearable } from '@dcl/schemas'
 import {
   Collection,
   CollectionAttributes,
@@ -221,7 +222,9 @@ export class ItemService {
         ? Bridge.mergeTPCollection(collection, lastItemCuration)
         : collection
 
-      const catalystItems = await peerAPI.fetchWearables([urn])
+      const catalystItems = await peerAPI.fetchWearables<ThirdPartyWearable>([
+        urn,
+      ])
       if (catalystItems.length > 0) {
         item = Bridge.mergeTPItem(dbItem, collection, catalystItems[0])
       }
@@ -260,7 +263,9 @@ export class ItemService {
         collection = Bridge.mergeCollection(dbCollection, remoteCollection)
 
         if (remoteItem) {
-          const [catalystItem] = await peerAPI.fetchWearables([remoteItem.urn])
+          const [catalystItem] = await peerAPI.fetchWearables<StandardWearable>(
+            [remoteItem.urn]
+          )
           item = Bridge.mergeItem(
             dbItem,
             remoteItem,
@@ -548,7 +553,9 @@ export class ItemService {
           )
 
           // Check if the new URN is not already in use
-          const [wearable] = await peerAPI.fetchWearables([itemURN])
+          const [wearable] = await peerAPI.fetchWearables<ThirdPartyWearable>([
+            itemURN,
+          ])
           if (wearable) {
             throw new ThirdPartyItemAlreadyPublishedError(
               item.id,
@@ -573,7 +580,9 @@ export class ItemService {
       )
 
       // Check if the chosen URN is already in use
-      const [wearable] = await peerAPI.fetchWearables([itemURN])
+      const [wearable] = await peerAPI.fetchWearables<ThirdPartyWearable>([
+        itemURN,
+      ])
       if (wearable) {
         throw new ThirdPartyItemAlreadyPublishedError(
           item.id,

--- a/src/Item/Item.types.ts
+++ b/src/Item/Item.types.ts
@@ -1,4 +1,3 @@
-import { Wearable } from '../ethereum/api/peer'
 import { ItemCurationAttributes } from '../Curation/ItemCuration'
 import { MetricsAttributes } from '../Metrics'
 import { Cheque } from '../SlotUsageCheque'
@@ -35,7 +34,6 @@ export type ItemAttributes = {
   eth_address: string
   collection_id: string | null
   blockchain_item_id: string | null
-  content_hash: string | null
   local_content_hash: string | null
   price: string | null
   beneficiary?: string | null
@@ -64,9 +62,11 @@ export type FullItem = Omit<ItemAttributes, 'urn_suffix'> & {
   in_catalyst: boolean
   total_supply: number
   content_hash: string | null
+  catalyst_content_hash: string | null
 }
 
-export type DBItemApprovalData = Pick<ItemAttributes, 'id' | 'content_hash'>
+export type DBItemApprovalData = Pick<ItemAttributes, 'id'> &
+  Pick<FullItem, 'content_hash'>
 
 export type ItemApprovalData = {
   cheque: Cheque
@@ -76,18 +76,3 @@ export type ItemApprovalData = {
   >
   chequeWasConsumed: boolean
 }
-
-type BaseWearableEntityMetadata = Omit<
-  Wearable,
-  'createdAt' | 'updatedAt' | 'collectionAddress' | 'rarity'
-> & {
-  i18n: { code: string; text: string }[]
-  emoteDataV0?: { loop: boolean }
-}
-
-export type TPWearableEntityMetadata = BaseWearableEntityMetadata & {
-  content: ItemContents
-}
-
-export type StandardWearableEntityMetadata = BaseWearableEntityMetadata &
-  Pick<Wearable, 'collectionAddress' | 'rarity'>

--- a/src/Item/hashes.ts
+++ b/src/Item/hashes.ts
@@ -2,16 +2,20 @@ import {
   calculateMultipleHashesADR32LegacyQmHash,
   keccak256Hash,
 } from '@dcl/hashing'
+import {
+  Locale,
+  WearableCategory,
+  WearableRepresentation,
+  ThirdPartyWearable,
+  StandardWearable,
+  Rarity,
+  I18N,
+} from '@dcl/schemas'
 import { CollectionAttributes } from '../Collection'
 import { isStandardItemPublished } from '../ItemAndCollection/utils'
 import { getDecentralandItemURN, isTPCollection } from '../utils/urn'
 import { EmoteCategory, EmoteData } from './emote/types'
-import {
-  StandardWearableEntityMetadata,
-  ItemAttributes,
-  TPWearableEntityMetadata,
-  ItemType,
-} from './Item.types'
+import { ItemAttributes, ItemType } from './Item.types'
 import { buildTPItemURN, isTPItem } from './utils'
 
 const THUMBNAIL_PATH = 'thumbnail.png'
@@ -20,26 +24,26 @@ const IMAGE_PATH = 'image.png'
 function buildStandardWearableEntityMetadata(
   item: ItemAttributes,
   collection: CollectionAttributes
-): StandardWearableEntityMetadata {
+): StandardWearable & { emoteDataV0?: { loop: boolean } } {
   if (!isStandardItemPublished(item, collection)) {
     throw new Error(
       "The item's collection must be published to build its metadata"
     )
   }
 
-  const entity: StandardWearableEntityMetadata = {
+  const entity: StandardWearable & { emoteDataV0?: { loop: boolean } } = {
     id: getDecentralandItemURN(item, collection.contract_address!),
     name: item.name,
     description: item.description,
     collectionAddress: collection.contract_address!,
-    rarity: item.rarity!,
-    i18n: [{ code: 'en', text: item.name }],
+    rarity: (item.rarity! as unknown) as Rarity,
+    i18n: [{ code: 'en', text: item.name }] as I18N[],
     data: {
-      replaces: item.data.replaces,
-      hides: item.data.hides,
+      replaces: item.data.replaces as WearableCategory[],
+      hides: item.data.hides as WearableCategory[],
       tags: item.data.tags,
-      category: item.data.category,
-      representations: item.data.representations,
+      category: item.data.category as WearableCategory,
+      representations: item.data.representations as WearableRepresentation[],
     },
     image: IMAGE_PATH,
     thumbnail: THUMBNAIL_PATH,
@@ -58,7 +62,7 @@ function buildStandardWearableEntityMetadata(
 function buildTPWearableEntityMetadata(
   item: ItemAttributes,
   collection: CollectionAttributes
-): TPWearableEntityMetadata {
+): Omit<ThirdPartyWearable, 'merkleProof'> {
   return {
     id: buildTPItemURN(
       collection.third_party_id!,
@@ -67,13 +71,13 @@ function buildTPWearableEntityMetadata(
     ),
     name: item.name,
     description: item.description,
-    i18n: [{ code: 'en', text: item.name }],
+    i18n: [{ code: Locale.EN, text: item.name }],
     data: {
-      replaces: item.data.replaces,
-      hides: item.data.hides,
+      replaces: item.data.replaces as WearableCategory[],
+      hides: item.data.hides as WearableCategory[],
       tags: item.data.tags,
-      category: item.data.category,
-      representations: item.data.representations,
+      category: item.data.category as WearableCategory,
+      representations: item.data.representations as WearableRepresentation[],
     },
     image: IMAGE_PATH,
     thumbnail: THUMBNAIL_PATH,


### PR DESCRIPTION
This PR does the following:
- Adds the catalyst content hash property to the item, reflecting the content hash of TP items deployed in the catalyst.
- Uses the latest version of `@dcl/schemas` so the entity metadata matches what we're currently deploying.
- Changes the `fetchWearables` method to be generic, receiving `StandarWearable` or `ThirdPartyWearable`. It also removes a `toWearable` method that was not required.