### PR TITLE
feat: Paginate items endpoint by address and collection

### DIFF
--- a/src/Collection/Collection.model.ts
+++ b/src/Collection/Collection.model.ts
@@ -5,23 +5,48 @@ import { CollectionAttributes } from './Collection.types'
 export class Collection extends Model<CollectionAttributes> {
   static tableName = 'collections'
 
+  static findAll() {
+    return this.query<CollectionAttributes & { item_count: number }>(SQL`
+      SELECT *, (SELECT COUNT(*) FROM ${raw(
+        Item.tableName
+      )} WHERE items.collection_id = collections.id) as item_count
+        FROM ${raw(this.tableName)}
+      `)
+  }
+
+  static findByAllByAddress(address: string) {
+    return this.query<CollectionAttributes & { item_count: number }>(SQL`
+      SELECT *, (SELECT COUNT(*) FROM ${raw(
+        Item.tableName
+      )} WHERE items.collection_id = collections.id) as item_count
+        FROM ${raw(this.tableName)}
+        WHERE eth_address = ${address}
+      `)
+  }
+
   static findByIds(ids: string[]) {
-    return this.query<CollectionAttributes>(SQL`
-    SELECT *
+    return this.query<CollectionAttributes & { item_count: number }>(SQL`
+    SELECT *, (SELECT COUNT(*) FROM ${raw(
+      Item.tableName
+    )} WHERE items.collection_id = collections.id) as item_count
       FROM ${raw(this.tableName)}
       WHERE id = ANY(${ids})`)
   }
 
   static findByThirdPartyIds(thirdPartyIds: string[]) {
     return this.query<CollectionAttributes>(SQL`
-    SELECT *
+    SELECT *, (SELECT COUNT(*) FROM ${raw(
+      Item.tableName
+    )} WHERE items.collection_id = collections.id) as item_count
       FROM ${raw(this.tableName)}
       WHERE third_party_id = ANY(${thirdPartyIds})`)
   }
 
   static findByContractAddresses(contractAddresses: string[]) {
     return this.query<CollectionAttributes>(SQL`
-      SELECT *
+      SELECT *, (SELECT COUNT(*) FROM ${raw(
+        Item.tableName
+      )} WHERE items.collection_id = collections.id) as item_count
         FROM ${raw(this.tableName)}
         WHERE contract_address = ANY(${contractAddresses})`)
   }

--- a/src/Collection/Collection.router.spec.ts
+++ b/src/Collection/Collection.router.spec.ts
@@ -828,7 +828,7 @@ describe('Collection router', () => {
   describe('when retrieving all the collections', () => {
     beforeEach(() => {
       ;(isCommitteeMember as jest.Mock).mockResolvedValueOnce(true)
-      ;(Collection.find as jest.Mock)
+      ;(Collection.findAll as jest.Mock)
         .mockResolvedValueOnce([dbCollection])
         .mockResolvedValueOnce([])
       ;(Collection.findByContractAddresses as jest.Mock).mockResolvedValueOnce(
@@ -860,7 +860,9 @@ describe('Collection router', () => {
 
   describe('when retrieving the collections of an address', () => {
     beforeEach(() => {
-      ;(Collection.find as jest.Mock).mockReturnValueOnce([dbCollection])
+      ;(Collection.findByAllByAddress as jest.Mock).mockReturnValueOnce([
+        dbCollection,
+      ])
       ;(Collection.findByContractAddresses as jest.Mock).mockReturnValueOnce([])
       ;(Collection.findByThirdPartyIds as jest.Mock).mockReturnValueOnce([
         dbTPCollection,
@@ -909,7 +911,7 @@ describe('Collection router', () => {
     beforeEach(() => {
       mockExistsMiddleware(Collection, dbCollection.id)
       ;(hasPublicAccess as jest.Mock).mockResolvedValueOnce(true)
-      ;(Collection.findOne as jest.Mock).mockReturnValueOnce(dbCollection)
+      ;(Collection.findByIds as jest.Mock).mockReturnValueOnce([dbCollection])
       ;(collectionAPI.fetchCollection as jest.Mock).mockReturnValueOnce(null)
       url = `/collections/${dbCollection.id}`
     })
@@ -927,7 +929,7 @@ describe('Collection router', () => {
             },
             ok: true,
           })
-          expect(Collection.findOne).toHaveBeenCalledWith(dbCollection.id)
+          expect(Collection.findByIds).toHaveBeenCalledWith([dbCollection.id])
         })
     })
   })
@@ -943,9 +945,9 @@ describe('Collection router', () => {
       jest.spyOn(Date, 'now').mockReturnValueOnce(now)
       mockExistsMiddleware(Collection, dbCollection.id)
       mockCollectionAuthorizationMiddleware(dbCollection.id, wallet.address)
-      ;(Collection.findOne as jest.MockedFunction<
+      ;(Collection.findByIds as jest.MockedFunction<
         typeof Collection.findOne
-      >).mockResolvedValueOnce(dbCollection)
+      >).mockResolvedValueOnce([dbCollection])
       url = `/collections/${dbCollection.id}/lock`
     })
 
@@ -982,9 +984,9 @@ describe('Collection router', () => {
         ;(Collection.count as jest.MockedFunction<
           typeof Collection.count
         >).mockResolvedValueOnce(1)
-        ;(Collection.findOne as jest.MockedFunction<
+        ;(Collection.findByIds as jest.MockedFunction<
           typeof Collection.findOne
-        >).mockResolvedValueOnce(dbCollection)
+        >).mockResolvedValueOnce([dbCollection])
       })
 
       it('should fail with an error if the update throws', () => {
@@ -1052,9 +1054,9 @@ describe('Collection router', () => {
             wallet.address,
             true
           )
-          ;(Collection.findOne as jest.MockedFunction<
+          ;(Collection.findByIds as jest.MockedFunction<
             typeof Collection.findOne
-          >).mockResolvedValueOnce(dbTPCollection)
+          >).mockResolvedValueOnce([dbTPCollection])
         })
 
         describe('and it has third party items already published', () => {
@@ -1152,9 +1154,9 @@ describe('Collection router', () => {
       beforeEach(() => {
         mockExistsMiddleware(Collection, dbCollection.id)
         mockCollectionAuthorizationMiddleware(dbCollection.id, wallet.address)
-        ;(Collection.findOne as jest.MockedFunction<
+        ;(Collection.findByIds as jest.MockedFunction<
           typeof Collection.findOne
-        >).mockResolvedValueOnce(dbCollection)
+        >).mockResolvedValueOnce([dbCollection])
       })
 
       describe('and it is already published', () => {
@@ -1259,9 +1261,9 @@ describe('Collection router', () => {
       describe('when sending an empty item ids array', () => {
         beforeEach(() => {
           ;(Item.findByIds as jest.Mock).mockResolvedValueOnce([])
-          ;(Collection.findOne as jest.Mock).mockResolvedValueOnce(
-            dbTPCollection
-          )
+          ;(Collection.findByIds as jest.Mock).mockResolvedValueOnce([
+            dbTPCollection,
+          ])
         })
 
         it('should respond with a 400 and a message signaling the item ids should not be empty', () => {
@@ -1291,9 +1293,9 @@ describe('Collection router', () => {
         let items: ItemAttributes[]
 
         beforeEach(() => {
-          ;(Collection.findOne as jest.Mock).mockResolvedValueOnce(
-            dbTPCollection
-          )
+          ;(Collection.findByIds as jest.Mock).mockResolvedValueOnce([
+            dbTPCollection,
+          ])
           items = [
             { ...dbTPItemMock, id: 'c241ef7c-4466-41b0-bf94-be1b8c331fdb' },
             { ...dbTPItemMock, id: 'anotherId' },
@@ -1327,9 +1329,9 @@ describe('Collection router', () => {
 
       describe('when sending an invalid signature', () => {
         beforeEach(() => {
-          ;(Collection.findOne as jest.Mock).mockResolvedValueOnce(
-            dbTPCollection
-          )
+          ;(Collection.findByIds as jest.Mock).mockResolvedValueOnce([
+            dbTPCollection,
+          ])
           ;(Item.findByIds as jest.Mock).mockResolvedValueOnce([dbTPItemMock])
         })
 
@@ -1364,9 +1366,9 @@ describe('Collection router', () => {
         let itemIds: string[]
 
         beforeEach(() => {
-          ;(Collection.findOne as jest.Mock).mockResolvedValueOnce(
-            dbTPCollection
-          )
+          ;(Collection.findByIds as jest.Mock).mockResolvedValueOnce([
+            dbTPCollection,
+          ])
           items = [
             { ...dbTPItemMock, id: uuid(), collection_id: '1' },
             { ...dbTPItemMock, id: uuid(), collection_id: '1' },
@@ -1410,9 +1412,9 @@ describe('Collection router', () => {
 
       describe('when the collection already has a pending ItemCuration', () => {
         beforeEach(() => {
-          ;(Collection.findOne as jest.Mock).mockResolvedValueOnce(
-            dbTPCollection
-          )
+          ;(Collection.findByIds as jest.Mock).mockResolvedValueOnce([
+            dbTPCollection,
+          ])
           ;(Item.findByIds as jest.Mock).mockResolvedValueOnce([dbItemMock])
           ;(ItemCuration.findLastCreatedByCollectionIdAndStatus as jest.Mock).mockResolvedValueOnce(
             itemCurationMock
@@ -1456,9 +1458,9 @@ describe('Collection router', () => {
         let slotUsageCheque: SlotUsageChequeAttributes
 
         beforeEach(() => {
-          ;(Collection.findOne as jest.Mock).mockResolvedValueOnce(
-            dbTPCollection
-          )
+          ;(Collection.findByIds as jest.Mock).mockResolvedValueOnce([
+            dbTPCollection,
+          ])
           dbItems = [
             { ...dbItemMock, id: uuid() },
             { ...dbItemMock, id: uuid() },
@@ -1576,9 +1578,6 @@ describe('Collection router', () => {
           ;(ItemCuration.create as jest.Mock).mockResolvedValue(
             itemCurationMock
           )
-          ;(Collection.findByIds as jest.Mock).mockResolvedValueOnce([
-            dbTPCollectionMock,
-          ])
           ;(createPost as jest.Mock).mockResolvedValueOnce({
             id: forumId,
             link: forumLink,
@@ -1591,9 +1590,9 @@ describe('Collection router', () => {
 
         describe('and the item collection does not have a virtual curation', () => {
           beforeEach(() => {
-            ;(Collection.findOne as jest.Mock).mockResolvedValueOnce(
-              dbTPCollection
-            )
+            ;(Collection.findByIds as jest.Mock).mockResolvedValueOnce([
+              dbTPCollection,
+            ])
           })
           it('should create a SlotUsageCheque record with the request data', () => {
             return server
@@ -1669,9 +1668,9 @@ describe('Collection router', () => {
           let collectionCuration: CollectionCurationAttributes
 
           beforeEach(() => {
-            ;(Collection.findOne as jest.Mock).mockResolvedValueOnce(
-              dbTPCollection
-            )
+            ;(Collection.findByIds as jest.Mock).mockResolvedValueOnce([
+              dbTPCollection,
+            ])
             collectionCuration = { id: uuid() } as CollectionCurationAttributes
             ;(CollectionCuration.findOne as jest.Mock).mockResolvedValueOnce(
               collectionCuration
@@ -1715,9 +1714,9 @@ describe('Collection router', () => {
 
           describe('and the collection is being published for the first time', () => {
             beforeEach(() => {
-              ;(Collection.findOne as jest.Mock).mockResolvedValueOnce(
-                dbTPCollection
-              )
+              ;(Collection.findByIds as jest.Mock).mockResolvedValueOnce([
+                dbTPCollection,
+              ])
             })
             it('should create a forum post with the response data', () => {
               return server
@@ -1793,10 +1792,12 @@ describe('Collection router', () => {
             let forumId: number
             beforeEach(() => {
               forumId = 1
-              ;(Collection.findOne as jest.Mock).mockResolvedValueOnce({
-                ...dbTPCollection,
-                forum_id: forumId,
-              })
+              ;(Collection.findByIds as jest.Mock).mockResolvedValueOnce([
+                {
+                  ...dbTPCollection,
+                  forum_id: forumId,
+                },
+              ])
             })
             it('should update the forum post with the response data', () => {
               return server
@@ -1825,7 +1826,9 @@ describe('Collection router', () => {
     describe('and the collection is a Decentraland collection', () => {
       beforeEach(() => {
         url = `/collections/${dbTPCollection.id}/publish`
-        ;(Collection.findOne as jest.Mock).mockResolvedValueOnce(dbCollection)
+        ;(Collection.findByIds as jest.Mock).mockResolvedValueOnce([
+          dbCollection,
+        ])
         mockExistsMiddleware(Collection, dbCollection.id)
       })
 
@@ -1915,7 +1918,7 @@ describe('Collection router', () => {
             >).mockResolvedValueOnce([dbItemMock, anotherDBItem])
             ;(Collection.findByIds as jest.MockedFunction<
               typeof Collection.findByIds
-            >).mockResolvedValueOnce([dbCollection])
+            >).mockResolvedValueOnce([{ ...dbCollection, item_count: 1 }])
             ;(peerAPI.fetchWearables as jest.MockedFunction<
               typeof peerAPI.fetchWearables
             >).mockResolvedValueOnce([])
@@ -1987,9 +1990,9 @@ describe('Collection router', () => {
             true,
             false
           )
-          ;(Collection.findOne as jest.Mock).mockResolvedValueOnce(
-            dbTPCollection
-          )
+          ;(Collection.findByIds as jest.Mock).mockResolvedValueOnce([
+            dbTPCollection,
+          ])
         })
 
         it('should respond with a 401 and a message signaling that the user is not authorized to upsert the collection', () => {
@@ -2041,9 +2044,9 @@ describe('Collection router', () => {
             true,
             true
           )
-          ;(Collection.findOne as jest.Mock).mockResolvedValueOnce(
-            dbTPCollection
-          )
+          ;(Collection.findByIds as jest.Mock).mockResolvedValueOnce([
+            dbTPCollection,
+          ])
           ;(Item.findDBApprovalDataByCollectionId as jest.Mock).mockResolvedValueOnce(
             []
           )
@@ -2077,9 +2080,9 @@ describe('Collection router', () => {
             true,
             true
           )
-          ;(Collection.findOne as jest.Mock).mockResolvedValueOnce(
-            dbTPCollection
-          )
+          ;(Collection.findByIds as jest.Mock).mockResolvedValueOnce([
+            dbTPCollection,
+          ])
           ;(Item.findDBApprovalDataByCollectionId as jest.Mock).mockResolvedValueOnce(
             [{}]
           )
@@ -2128,9 +2131,9 @@ describe('Collection router', () => {
               true,
               true
             )
-            ;(Collection.findOne as jest.Mock).mockResolvedValueOnce(
-              dbTPCollection
-            )
+            ;(Collection.findByIds as jest.Mock).mockResolvedValueOnce([
+              dbTPCollection,
+            ])
             ;(Item.findDBApprovalDataByCollectionId as jest.Mock).mockResolvedValueOnce(
               itemApprovalData
             )
@@ -2188,9 +2191,9 @@ describe('Collection router', () => {
               true,
               true
             )
-            ;(Collection.findOne as jest.Mock).mockResolvedValueOnce(
-              dbTPCollection
-            )
+            ;(Collection.findByIds as jest.Mock).mockResolvedValueOnce([
+              dbTPCollection,
+            ])
             ;(Item.findDBApprovalDataByCollectionId as jest.Mock).mockResolvedValueOnce(
               itemApprovalData
             )
@@ -2280,7 +2283,7 @@ describe('Collection router', () => {
         true,
         true
       )
-      ;(Collection.findOne as jest.Mock).mockResolvedValueOnce(dbCollection)
+      ;(Collection.findByIds as jest.Mock).mockResolvedValueOnce([dbCollection])
       ;(SlotUsageCheque.findLastByCollectionId as jest.Mock).mockResolvedValueOnce(
         {}
       )

--- a/src/Collection/Collection.router.ts
+++ b/src/Collection/Collection.router.ts
@@ -213,7 +213,7 @@ export class CollectionRouter extends Router {
       remoteCollections,
       dbTPCollections,
     ] = await Promise.all([
-      Collection.find<CollectionAttributes>(),
+      Collection.findAll(),
       collectionAPI.fetchCollections(),
       this.service.getDbTPCollections(),
     ])
@@ -251,7 +251,7 @@ export class CollectionRouter extends Router {
       remoteCollections,
       dbTPCollections,
     ] = await Promise.all([
-      Collection.find<CollectionAttributes>({ eth_address }),
+      Collection.findByAllByAddress(eth_address),
       collectionAPI.fetchCollectionsByAuthorizedUser(eth_address),
       this.service.getDbTPCollectionsByManager(eth_address),
     ])

--- a/src/Collection/Collection.service.ts
+++ b/src/Collection/Collection.service.ts
@@ -528,12 +528,12 @@ export class CollectionService {
   public async getDBCollection(
     collectionId: string
   ): Promise<CollectionAttributes> {
-    const collection = await Collection.findOne(collectionId)
-    if (!collection) {
+    const collections = await Collection.findByIds([collectionId])
+    if (!collections.length) {
       throw new NonExistentCollectionError(collectionId)
     }
 
-    return collection
+    return collections[0]
   }
 
   /**

--- a/src/Item/Item.router.spec.ts
+++ b/src/Item/Item.router.spec.ts
@@ -69,7 +69,8 @@ jest.mock('./Item.model')
 
 function mockItemConsolidation(
   itemsAttributes: ItemAttributes[],
-  wearables: CatalystItem[]
+  wearables: CatalystItem[],
+  collection = dbCollectionMock
 ) {
   ;(Item.findByBlockchainIdsAndContractAddresses as jest.Mock).mockResolvedValueOnce(
     itemsAttributes
@@ -78,7 +79,7 @@ function mockItemConsolidation(
   ;(collectionAPI.buildItemId as jest.Mock).mockImplementation(
     (contractAddress, tokenId) => contractAddress + '-' + tokenId
   )
-  ;(Collection.findByIds as jest.Mock).mockResolvedValueOnce([dbCollectionMock])
+  ;(Collection.findByIds as jest.Mock).mockResolvedValueOnce([collection])
 }
 
 const server = supertest(app.getApp())
@@ -295,11 +296,11 @@ describe('Item router', () => {
 
   describe('when getting all the items of an address', () => {
     beforeEach(() => {
-      ;(Item.findNonThirdPartyItemsByOwner as jest.Mock).mockResolvedValueOnce([
+      ;(Item.findStandardAndTPItems as jest.Mock).mockResolvedValueOnce([
         dbItem,
         dbItemNotPublished,
+        dbTPItem,
       ])
-      ;(Item.findByThirdPartyIds as jest.Mock).mockResolvedValueOnce([dbTPItem])
       ;(thirdPartyAPI.fetchThirdPartiesByManager as jest.Mock).mockResolvedValueOnce(
         [thirdPartyFragmentMock]
       )
@@ -315,54 +316,13 @@ describe('Item router', () => {
       ;(ItemCuration.find as jest.Mock).mockResolvedValueOnce([dbItemCuration])
       mockItemConsolidation([dbItem], [wearable])
       ;(peerAPI.fetchWearables as jest.Mock).mockResolvedValueOnce([tpWearable])
-      url = `/${wallet.address}/items`
     })
 
-    it('should return all the items of an address that are published with URN and the ones that are not without it', () => {
-      return server
-        .get(buildURL(url))
-        .set(createAuthHeaders('get', url))
-        .expect(200)
-        .then((response: any) => {
-          expect(response.body).toEqual({
-            data: [
-              {
-                ...resultingItem,
-                beneficiary: itemFragment.beneficiary,
-                collection_id: dbItem.collection_id,
-                blockchain_item_id: dbItem.blockchain_item_id,
-                urn: itemFragmentMock.urn,
-              },
-              resultItemNotPublished,
-              resultingTPItem,
-            ],
-            ok: true,
-          })
-        })
-    })
-  })
-
-  describe('when getting all the items of a collection', () => {
-    describe('and the collection is a DCL collection', () => {
+    describe('and there pagination params are not passed', () => {
       beforeEach(() => {
-        ;(Item.find as jest.Mock).mockResolvedValueOnce([
-          dbItemMock,
-          dbItemNotPublished,
-        ])
-        ;(collectionAPI.fetchCollectionWithItemsByContractAddress as jest.Mock).mockResolvedValueOnce(
-          { collection: itemFragment.collection, items: [itemFragment] }
-        )
-        ;(Collection.findOne as jest.Mock).mockResolvedValueOnce(
-          dbCollectionMock
-        )
-        ;(Collection.findByIds as jest.Mock).mockResolvedValueOnce([
-          dbCollectionMock,
-        ])
-        mockItemConsolidation([dbItemMock], [wearable])
-        url = `/collections/${dbCollectionMock.id}/items`
+        url = `/${wallet.address}/items`
       })
-
-      it('should return all the items of a collection with their URN', () => {
+      it('should return all the items of an address that are published with URN and the ones that are not without it', () => {
         return server
           .get(buildURL(url))
           .set(createAuthHeaders('get', url))
@@ -378,16 +338,126 @@ describe('Item router', () => {
                   urn: itemFragmentMock.urn,
                 },
                 resultItemNotPublished,
+                resultingTPItem,
               ],
               ok: true,
             })
+            expect(Item.findStandardAndTPItems).toHaveBeenCalledWith(
+              [thirdPartyFragmentMock.id],
+              wallet.address,
+              undefined,
+              undefined
+            )
           })
+      })
+    })
+
+    describe('and pagination params are passed', () => {
+      let baseUrl: string
+      let page: number
+      let limit: number
+      beforeEach(() => {
+        ;(page = 1), (limit = 0)
+        baseUrl = `/${wallet.address}/items`
+        url = `${baseUrl}?limit=${limit}&page=${page}`
+      })
+      it('should call the find method with the pagination params', () => {
+        return server
+          .get(buildURL(url))
+          .set(createAuthHeaders('get', baseUrl))
+          .expect(200)
+          .then(() => {
+            expect(Item.findStandardAndTPItems).toHaveBeenCalledWith(
+              [thirdPartyFragmentMock.id],
+              wallet.address,
+              limit,
+              page
+            )
+          })
+      })
+    })
+  })
+
+  describe('when getting all the items of a collection', () => {
+    describe('and the collection is a DCL collection', () => {
+      beforeEach(() => {
+        ;(Item.findByCollectionIds as jest.Mock).mockResolvedValueOnce([
+          dbItemMock,
+          dbItemNotPublished,
+        ])
+        ;(collectionAPI.fetchCollectionWithItemsByContractAddress as jest.Mock).mockResolvedValueOnce(
+          { collection: itemFragment.collection, items: [itemFragment] }
+        )
+        ;(Collection.findOne as jest.Mock).mockResolvedValueOnce(
+          dbCollectionMock
+        )
+        ;(Collection.findByIds as jest.Mock).mockResolvedValueOnce([
+          dbCollectionMock,
+        ])
+        mockItemConsolidation([dbItemMock], [wearable])
+        // url = `/collections/${dbCollectionMock.id}/items`
+      })
+
+      describe('and there pagination params are not passed', () => {
+        beforeEach(() => {
+          url = `/collections/${dbCollectionMock.id}/items`
+        })
+        it('should return all the items of a collection with their URN', () => {
+          return server
+            .get(buildURL(url))
+            .set(createAuthHeaders('get', url))
+            .expect(200)
+            .then((response: any) => {
+              expect(response.body).toEqual({
+                data: [
+                  {
+                    ...resultingItem,
+                    beneficiary: itemFragment.beneficiary,
+                    collection_id: dbItem.collection_id,
+                    blockchain_item_id: dbItem.blockchain_item_id,
+                    urn: itemFragmentMock.urn,
+                  },
+                  resultItemNotPublished,
+                ],
+                ok: true,
+              })
+              expect(Item.findByCollectionIds).toHaveBeenCalledWith(
+                [dbCollectionMock.id],
+                undefined,
+                undefined
+              )
+            })
+        })
+      })
+
+      describe('and pagination params are passed', () => {
+        let baseUrl: string
+        let page: number
+        let limit: number
+        beforeEach(() => {
+          ;(page = 1), (limit = 1)
+          baseUrl = `/collections/${dbCollectionMock.id}/items`
+          url = `${baseUrl}?limit=${limit}&page=${page}`
+        })
+        fit('should call the find method with the pagination params', () => {
+          return server
+            .get(buildURL(url))
+            .set(createAuthHeaders('get', baseUrl))
+            .expect(200)
+            .then(() => {
+              expect(Item.findByCollectionIds).toHaveBeenCalledWith(
+                [dbCollectionMock.id],
+                limit,
+                limit * (page - 1)
+              )
+            })
+        })
       })
     })
 
     describe('and the collection is a third party collection', () => {
       beforeEach(() => {
-        ;(Item.find as jest.Mock).mockResolvedValueOnce([
+        ;(Item.findByCollectionIds as jest.Mock).mockResolvedValueOnce([
           dbTPItem,
           dbTPItemPublished,
           dbTPItemNotPublished,
@@ -401,7 +471,7 @@ describe('Item router', () => {
         ;(ItemCuration.findByCollectionId as jest.Mock).mockResolvedValueOnce([
           dbItemCuration,
         ])
-        mockItemConsolidation([dbItemMock], [tpWearable])
+        mockItemConsolidation([dbItemMock], [tpWearable], dbTPCollectionMock)
         url = `/collections/${dbCollectionMock.id}/items`
       })
 
@@ -455,7 +525,9 @@ describe('Item router', () => {
             collection_id: tpCollectionMock.id,
           }
           mockItem.findOne.mockResolvedValueOnce(itemToUpsert)
-          mockCollection.findOne.mockResolvedValueOnce(tpCollectionMock)
+          ;(Collection.findByIds as jest.Mock).mockResolvedValueOnce([
+            dbCollectionMock,
+          ])
           mockIsThirdPartyManager(wallet.address, false)
         })
 
@@ -564,7 +636,9 @@ describe('Item router', () => {
               collection_id: tpCollectionMock.id,
               urn_suffix: itemUrnSuffix,
             })
-            mockCollection.findOne.mockResolvedValueOnce(tpCollectionMock)
+            mockCollection.findByIds.mockResolvedValueOnce([
+              { ...tpCollectionMock, item_count: 1 },
+            ])
           })
 
           describe('and is not published', () => {
@@ -637,7 +711,9 @@ describe('Item router', () => {
               collection_id: null,
               urn_suffix: null,
             })
-            mockCollection.findOne.mockResolvedValueOnce(tpCollectionMock)
+            mockCollection.findByIds.mockResolvedValueOnce([
+              { ...tpCollectionMock, item_count: 1 },
+            ])
             itemToUpsert = {
               ...itemToUpsert,
               collection_id: tpCollectionMock.id,
@@ -765,7 +841,9 @@ describe('Item router', () => {
               collection_id: tpCollectionMock.id,
               urn_suffix: itemUrnSuffix,
             })
-            mockCollection.findOne.mockResolvedValueOnce(tpCollectionMock)
+            mockCollection.findByIds.mockResolvedValueOnce([
+              { ...tpCollectionMock, item_count: 1 },
+            ])
           })
 
           describe('and the URN changes', () => {
@@ -904,7 +982,9 @@ describe('Item router', () => {
       describe('and the item is being inserted', () => {
         beforeEach(() => {
           mockItem.findOne.mockResolvedValueOnce(undefined)
-          mockCollection.findOne.mockResolvedValueOnce(tpCollectionMock)
+          mockCollection.findByIds.mockResolvedValueOnce([
+            { ...tpCollectionMock, item_count: 1 },
+          ])
           mockIsThirdPartyManager(wallet.address, true)
         })
 
@@ -1101,7 +1181,9 @@ describe('Item router', () => {
         beforeEach(() => {
           itemToUpsert = { ...itemToUpsert, collection_id: null }
           mockItem.findOne.mockResolvedValueOnce(itemToUpsert)
-          mockCollection.findOne.mockResolvedValueOnce(undefined)
+          mockCollection.findByIds.mockResolvedValueOnce([
+            { ...tpCollectionMock, item_count: 1 },
+          ])
           mockOwnableCanUpsert(Item, itemToUpsert.id, wallet.address, false)
         })
 
@@ -1123,7 +1205,7 @@ describe('Item router', () => {
       describe('and the collection provided in the payload does not exists in the db', () => {
         beforeEach(() => {
           mockItem.findOne.mockResolvedValueOnce(itemToUpsert)
-          mockCollection.findOne.mockResolvedValueOnce(undefined)
+          mockCollection.findByIds.mockResolvedValueOnce([])
         })
 
         it('should fail with collection not found message', async () => {
@@ -1145,11 +1227,13 @@ describe('Item router', () => {
         const differentEthAddress = '0xc6d2000a7a1ddca92941f4e2b41360fe4ee2abd8'
         beforeEach(() => {
           mockItem.findOne.mockResolvedValueOnce(itemToUpsert)
-          mockCollection.findOne.mockResolvedValueOnce({
-            ...collectionMock,
-            collection_id: dbItem.collection_id,
-            eth_address: differentEthAddress,
-          })
+          mockCollection.findByIds.mockResolvedValueOnce([
+            {
+              ...collectionMock,
+              eth_address: differentEthAddress,
+              item_count: 1,
+            },
+          ])
           mockOwnableCanUpsert(Item, itemToUpsert.id, wallet.address, true)
         })
 
@@ -1176,11 +1260,13 @@ describe('Item router', () => {
       describe('and the collection of the item is being changed', () => {
         beforeEach(() => {
           mockItem.findOne.mockResolvedValueOnce(itemToUpsert)
-          mockCollection.findOne.mockResolvedValueOnce({
-            ...collectionMock,
-            collection_id: itemToUpsert.collection_id,
-            eth_address: wallet.address,
-          })
+          mockCollection.findByIds.mockResolvedValueOnce([
+            {
+              ...collectionMock,
+              eth_address: wallet.address,
+              item_count: 1,
+            },
+          ])
           mockOwnableCanUpsert(Item, itemToUpsert.id, wallet.address, true)
         })
 
@@ -1201,13 +1287,15 @@ describe('Item router', () => {
 
       describe('when the collection given for the item is locked', () => {
         beforeEach(() => {
-          mockCollection.findOne.mockResolvedValueOnce({
-            ...collectionMock,
-            collection_id: itemToUpsert.collection_id,
-            eth_address: wallet.address,
-            contract_address: Wallet.createRandom().address,
-            lock: new Date(),
-          })
+          mockCollection.findByIds.mockResolvedValueOnce([
+            {
+              ...collectionMock,
+              eth_address: wallet.address,
+              contract_address: Wallet.createRandom().address,
+              lock: new Date(),
+              item_count: 1,
+            },
+          ])
           mockOwnableCanUpsert(Item, itemToUpsert.id, wallet.address, true)
           mockIsCollectionPublished(dbCollectionMock.id, false)
         })
@@ -1239,12 +1327,14 @@ describe('Item router', () => {
       describe('when the collection given for the item is already published', () => {
         beforeEach(() => {
           dbItem.collection_id = collectionMock.id
-          mockCollection.findOne.mockResolvedValueOnce({
-            ...collectionMock,
-            collection_id: itemToUpsert.collection_id,
-            eth_address: wallet.address,
-            contract_address: '0x3DC9C91cAB92E5806250E2f5cabe711ad79296ea',
-          })
+          mockCollection.findByIds.mockResolvedValueOnce([
+            {
+              ...collectionMock,
+              eth_address: wallet.address,
+              contract_address: '0x3DC9C91cAB92E5806250E2f5cabe711ad79296ea',
+              item_count: 1,
+            },
+          ])
           mockOwnableCanUpsert(Item, itemToUpsert.id, wallet.address, true)
           mockIsCollectionPublished(collectionMock.id, true)
         })
@@ -1262,7 +1352,7 @@ describe('Item router', () => {
               .expect(STATUS_CODES.conflict)
 
             expect(mockItem.findOne).toHaveBeenCalledTimes(1)
-            expect(mockCollection.findOne).toHaveBeenCalledTimes(1)
+            expect(mockCollection.findByIds).toHaveBeenCalledTimes(1)
 
             expect(response.body).toEqual({
               data: { id: itemToUpsert.id },
@@ -1366,12 +1456,14 @@ describe('Item router', () => {
           currentDate = new Date()
           jest.useFakeTimers()
           jest.setSystemTime(currentDate)
-          mockCollection.findOne.mockResolvedValueOnce({
-            ...collectionMock,
-            collection_id: itemToUpsert.collection_id,
-            eth_address: wallet.address,
-            contract_address: null,
-          })
+          mockCollection.findByIds.mockResolvedValueOnce([
+            {
+              ...collectionMock,
+              eth_address: wallet.address,
+              contract_address: null,
+              item_count: 1,
+            },
+          ])
           mockItem.findOne.mockResolvedValueOnce(undefined)
           mockOwnableCanUpsert(Item, itemToUpsert.id, wallet.address, true)
           mockIsCollectionPublished(collectionMock.id, false)
@@ -1495,9 +1587,14 @@ describe('Item router', () => {
           ;(Item.findOne as jest.MockedFunction<
             typeof Item.findOne
           >).mockResolvedValueOnce(dbItem)
-          ;(Collection.findOne as jest.MockedFunction<
-            typeof Collection.findOne
-          >).mockResolvedValueOnce(dbCollectionMock)
+          ;(Collection.findByIds as jest.MockedFunction<
+            typeof Collection.findByIds
+          >).mockResolvedValueOnce([
+            {
+              ...dbCollectionMock,
+              item_count: 1,
+            },
+          ])
         })
 
         describe('and its collection is already published', () => {
@@ -1539,9 +1636,14 @@ describe('Item router', () => {
           ;(Item.findOne as jest.MockedFunction<
             typeof Item.findOne
           >).mockResolvedValueOnce(dbTPItem)
-          ;(Collection.findOne as jest.MockedFunction<
-            typeof Collection.findOne
-          >).mockResolvedValueOnce(dbCollectionMock)
+          ;(Collection.findByIds as jest.MockedFunction<
+            typeof Collection.findByIds
+          >).mockResolvedValueOnce([
+            {
+              ...dbCollectionMock,
+              item_count: 1,
+            },
+          ])
         })
 
         it('should respond a 500, a message signaling that the third party item belongs to a non third party collection and not delete the item', () => {
@@ -1578,12 +1680,15 @@ describe('Item router', () => {
           >).mockResolvedValueOnce(dbTPItem)
           const currentDate = Date.now()
           jest.spyOn(Date, 'now').mockReturnValueOnce(currentDate)
-          ;(Collection.findOne as jest.MockedFunction<
-            typeof Collection.findOne
-          >).mockResolvedValueOnce({
-            ...dbTPCollectionMock,
-            lock: new Date(currentDate),
-          })
+          ;(Collection.findByIds as jest.MockedFunction<
+            typeof Collection.findByIds
+          >).mockResolvedValueOnce([
+            {
+              ...dbTPCollectionMock,
+              item_count: 1,
+              lock: new Date(currentDate),
+            },
+          ])
         })
 
         afterEach(() => {
@@ -1622,9 +1727,9 @@ describe('Item router', () => {
           ;(Item.findOne as jest.MockedFunction<
             typeof Item.findOne
           >).mockResolvedValueOnce(dbTPItem)
-          ;(Collection.findOne as jest.MockedFunction<
-            typeof Collection.findOne
-          >).mockResolvedValueOnce(dbTPCollectionMock)
+          ;(Collection.findByIds as jest.MockedFunction<
+            typeof Collection.findByIds
+          >).mockResolvedValueOnce([{ ...dbTPCollectionMock, item_count: 1 }])
           mockThirdPartyItemCurationExists(dbTPItem.id, true)
         })
 
@@ -1665,9 +1770,9 @@ describe('Item router', () => {
           ;(Item.findOne as jest.MockedFunction<
             typeof Item.findOne
           >).mockResolvedValueOnce(dbTPItem)
-          ;(Collection.findOne as jest.MockedFunction<
-            typeof Collection.findOne
-          >).mockResolvedValueOnce(dbTPCollectionMock)
+          ;(Collection.findByIds as jest.MockedFunction<
+            typeof Collection.findByIds
+          >).mockResolvedValueOnce([{ ...dbTPCollectionMock, item_count: 1 }])
           mockThirdPartyItemCurationExists(dbTPItem.id, false)
         })
 

--- a/src/Item/Item.types.ts
+++ b/src/Item/Item.types.ts
@@ -67,3 +67,15 @@ export type ItemApprovalData = {
   >
   chequeWasConsumed: boolean
 }
+
+export type PaginationAttributes = {
+  total_count: number
+}
+
+export type PaginatedResponse<T> = {
+  results: T[]
+  total: number
+  page: number
+  pages: number
+  limit: number
+}

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -1,0 +1,32 @@
+import { Request } from 'express'
+
+export const getPaginationParams = (req: Request) => {
+  const { limit, page } = req.query
+  const parsedLimit = Number(limit)
+  const parsedPage = Number(page)
+  return {
+    limit: limit && !isNaN(parsedLimit) ? parsedLimit : undefined,
+    page: page && !isNaN(parsedPage) ? parsedPage : undefined,
+  }
+}
+
+export const getOffset = (page?: number, limit?: number) => {
+  return limit && page ? limit * (page - 1) : undefined
+}
+
+export const generatePaginatedResponse = <T>(
+  results: T,
+  total: number,
+  limit: number,
+  page: number
+) => {
+  const pages = Math.ceil(total / Number(limit))
+
+  return {
+    total,
+    limit,
+    pages,
+    page,
+    results,
+  }
+}


### PR DESCRIPTION
This PR includes:

- [X] Adds `item_count` property to the collection endpoints.
- [X] Paginates `/:address/items` endpoint
- [X] Paginates `/:collection/items` endpoint