### PR TITLE
fix: Add missing FORUM_API_USERNAME in the ci file

### DIFF
--- a/.ci/index.ts
+++ b/.ci/index.ts
@@ -113,6 +113,10 @@ export = async function main() {
         value: config.requireSecret('FORUM_API_KEY'),
       },
       {
+        name: 'FORUM_API_USERNAME',
+        value: 'collections',
+      },
+      {
         name: 'FORUM_URL',
         value: 'https://forum.decentraland.org',
       },


### PR DESCRIPTION
Closes #479

Description: 

The `FORUM_API_USERNAME` env var was missing in the `ci` file so it was not defined in the builder's deployed version. 