### PR TITLE
fix: Increase collection name length

### DIFF
--- a/src/Collection/Collection.schema.ts
+++ b/src/Collection/Collection.schema.ts
@@ -5,7 +5,7 @@ export const collectionSchema = Object.freeze({
   properties: {
     id: { type: 'string', format: 'uuid' },
     urn: { type: ['string', 'null'], pattern: matchers.urn },
-    name: { type: 'string', maxLength: 32 },
+    name: { type: 'string', maxLength: 42 },
     eth_address: { type: 'string' },
     salt: { type: ['string', 'null'] },
     contract_address: { type: ['string', 'null'] },

--- a/src/Item/Item.schema.ts
+++ b/src/Item/Item.schema.ts
@@ -11,7 +11,7 @@ export const itemSchema = Object.freeze({
   properties: {
     id: { type: 'string', format: 'uuid' },
     urn: { type: ['string', 'null'], pattern: matchers.urn },
-    name: { type: 'string', maxLength: 42, pattern: '^[^:]*$' },
+    name: { type: 'string', maxLength: 32, pattern: '^[^:]*$' },
     description: {
       type: ['string', 'null'],
       maxLength: 64,

--- a/src/Item/Item.schema.ts
+++ b/src/Item/Item.schema.ts
@@ -11,7 +11,7 @@ export const itemSchema = Object.freeze({
   properties: {
     id: { type: 'string', format: 'uuid' },
     urn: { type: ['string', 'null'], pattern: matchers.urn },
-    name: { type: 'string', maxLength: 32, pattern: '^[^:]*$' },
+    name: { type: 'string', maxLength: 42, pattern: '^[^:]*$' },
     description: {
       type: ['string', 'null'],
       maxLength: 64,


### PR DESCRIPTION
This PR increases the collection name length to 42 to include Ethereum addresses (40 chars length plus '0x').

Closes #477