### PR TITLE
feat: Add collectionId query param to the items per address endpoint

### DIFF
--- a/src/Item/Item.model.ts
+++ b/src/Item/Item.model.ts
@@ -70,7 +70,7 @@ export class Item extends Model<ItemAttributes> {
 
   // PAGINATED QUERIES
 
-  static findAllItemsByAddress(
+  static findItemsByAddress(
     address: string,
     thirdPartyIds: string[],
     parmas: {

--- a/src/Item/Item.model.ts
+++ b/src/Item/Item.model.ts
@@ -71,24 +71,37 @@ export class Item extends Model<ItemAttributes> {
   // PAGINATED QUERIES
 
   static findAllItemsByAddress(
-    thirdPartyIds: string[],
     address: string,
-    limit: number = DEFAULT_LIMIT,
-    offset: number = 0
+    thirdPartyIds: string[],
+    parmas: {
+      collectionId?: string
+      limit?: number
+      offset?: number
+    }
   ) {
+    const { collectionId, limit, offset } = parmas
     return this.query<ItemWithTotalCount>(SQL`
       SELECT items.*, count(*) OVER() AS total_count
         FROM ${raw(this.tableName)} items
-        JOIN ${raw(
+        LEFT JOIN ${raw(
           Collection.tableName
         )} collections ON collections.id = items.collection_id
-        WHERE 
-          collections.third_party_id = ANY(${thirdPartyIds})
-        OR
-          (items.eth_address = ${address} AND items.urn_suffix IS NULL)
+        WHERE
+          (
+            collections.third_party_id = ANY(${thirdPartyIds})
+          OR
+            (items.eth_address = ${address} AND items.urn_suffix IS NULL)
+          )
+        ${
+          collectionId
+            ? SQL`AND items.collection_id ${
+                collectionId === 'null' ? SQL`is NULL` : SQL`= ${collectionId}`
+              }`
+            : SQL``
+        }
         LIMIT ${limit}
         OFFSET ${offset}
-      `)
+    `)
   }
 
   static async findByCollectionIds(

--- a/src/Item/Item.router.spec.ts
+++ b/src/Item/Item.router.spec.ts
@@ -298,7 +298,7 @@ describe('Item router', () => {
     let allAddressItems: ItemAttributes[]
     beforeEach(() => {
       allAddressItems = [dbItem, dbItemNotPublished, dbTPItem]
-      ;(Item.findAllItemsByAddress as jest.Mock).mockResolvedValueOnce(
+      ;(Item.findItemsByAddress as jest.Mock).mockResolvedValueOnce(
         allAddressItems.map((item) => ({
           ...item,
           total_count: allAddressItems.length,
@@ -345,7 +345,7 @@ describe('Item router', () => {
               ],
               ok: true,
             })
-            expect(Item.findAllItemsByAddress).toHaveBeenCalledWith(
+            expect(Item.findItemsByAddress).toHaveBeenCalledWith(
               wallet.address,
               [thirdPartyFragmentMock.id],
               {
@@ -358,14 +358,15 @@ describe('Item router', () => {
       })
     })
 
-    describe('and pagination params are passed', () => {
+    describe('and pagination & collectionId params are passed', () => {
       let baseUrl: string
       let page: number
       let limit: number
+      let collectionId: string
       beforeEach(() => {
-        ;(page = 1), (limit = 1)
+        ;(page = 1), (limit = 1), (collectionId = 'null')
         baseUrl = `/${wallet.address}/items`
-        url = `${baseUrl}?limit=${limit}&page=${page}`
+        url = `${baseUrl}?limit=${limit}&page=${page}&collectionId=${collectionId}`
       })
       it('should call the find method with the pagination params', () => {
         return server
@@ -393,13 +394,13 @@ describe('Item router', () => {
               },
               ok: true,
             })
-            expect(Item.findAllItemsByAddress).toHaveBeenCalledWith(
+            expect(Item.findItemsByAddress).toHaveBeenCalledWith(
               wallet.address,
               [thirdPartyFragmentMock.id],
               {
                 limit,
                 offset: page - 1, // it's the offset
-                collectionId: undefined,
+                collectionId,
               }
             )
           })

--- a/src/Item/Item.router.spec.ts
+++ b/src/Item/Item.router.spec.ts
@@ -346,10 +346,13 @@ describe('Item router', () => {
               ok: true,
             })
             expect(Item.findAllItemsByAddress).toHaveBeenCalledWith(
-              [thirdPartyFragmentMock.id],
               wallet.address,
-              undefined,
-              undefined
+              [thirdPartyFragmentMock.id],
+              {
+                page: undefined,
+                limit: undefined,
+                collecitonId: undefined,
+              }
             )
           })
       })
@@ -391,10 +394,13 @@ describe('Item router', () => {
               ok: true,
             })
             expect(Item.findAllItemsByAddress).toHaveBeenCalledWith(
-              [thirdPartyFragmentMock.id],
               wallet.address,
-              limit,
-              page - 1 // it's the offset
+              [thirdPartyFragmentMock.id],
+              {
+                limit,
+                offset: page - 1, // it's the offset
+                collectionId: undefined,
+              }
             )
           })
       })

--- a/src/Item/Item.router.ts
+++ b/src/Item/Item.router.ts
@@ -211,7 +211,7 @@ export class ItemRouter extends Router {
     const allItems = allItemsWithCount.map((itemWithCount) =>
       omit<ItemAttributes>(itemWithCount, ['total_count'])
     )
-    const collectionIds = allItems.map((item) => item.collection_id)
+    const dbBlockchainItemIds = allItems.map((item) => item.blockchain_item_id)
     const { items: dbItems, tpItems: dbTPItems } = this.itemService.splitItems(
       allItems
     )
@@ -220,7 +220,7 @@ export class ItemRouter extends Router {
       Bridge.consolidateItems(
         dbItems,
         remoteItems.filter((remoteItem) =>
-          collectionIds.includes(remoteItem.collection.id)
+          dbBlockchainItemIds.includes(remoteItem.blockchainId)
         )
       ),
       Bridge.consolidateTPItems(dbTPItems, itemCurations),

--- a/src/Item/Item.service.ts
+++ b/src/Item/Item.service.ts
@@ -178,7 +178,7 @@ export class ItemService {
 
     const thirdPartyIds = thirdParties.map((thirdParty) => thirdParty.id)
 
-    return Item.findAllItemsByAddress(address, thirdPartyIds, params)
+    return Item.findItemsByAddress(address, thirdPartyIds, params)
   }
 
   /**

--- a/src/Item/Item.service.ts
+++ b/src/Item/Item.service.ts
@@ -163,10 +163,13 @@ export class ItemService {
     }
   }
 
-  public async findAllItemsForAddress(
+  public async findItemsForAddress(
     address: string,
-    limit?: number,
-    offset?: number
+    params: {
+      collectionId?: string
+      limit?: number
+      offset?: number
+    }
   ): Promise<(ItemAttributes & { total_count: number })[]> {
     const thirdParties = await thirdPartyAPI.fetchThirdPartiesByManager(address)
     if (thirdParties.length <= 0) {
@@ -175,7 +178,7 @@ export class ItemService {
 
     const thirdPartyIds = thirdParties.map((thirdParty) => thirdParty.id)
 
-    return Item.findAllItemsByAddress(thirdPartyIds, address, limit, offset)
+    return Item.findAllItemsByAddress(address, thirdPartyIds, params)
   }
 
   /**

--- a/src/ethereum/api/fragments.ts
+++ b/src/ethereum/api/fragments.ts
@@ -149,6 +149,7 @@ export type ItemFragment = {
 }
 
 export type CollectionFragment = {
+  /** Collection address */
   id: string
   creator: string
   owner: string


### PR DESCRIPTION
## Why? 

As we introduced pagination for some of the pages in the UI, we faced the need of fetching just the "orphan" items for an address. By adding the `collectionId` query param, we can pass `collectionId=null` and get the items without a collection. 
This will be used in the `/collections` and `/item-editor` pages in the builder UI.


Adds JSDoc attr. to the CollectionFragment 
<img width="626" alt="image" src="https://user-images.githubusercontent.com/8763687/163198486-367adf46-8b3b-4808-88c7-c329c45670ca.png">

