### PR TITLE
fix: Remove the orderBy and orderDirection

### DIFF
--- a/src/ethereum/api/BaseGraphAPI.ts
+++ b/src/ethereum/api/BaseGraphAPI.ts
@@ -12,15 +12,11 @@ export const MAX_RESULTS = 1000
 export const PAGINATION_VARIABLES = `
   $first: Int = ${MAX_RESULTS}
   $skip: Int = 0
-  $orderBy: String
-  $orderDirection: String
 `
 
 export const PAGINATION_ARGUMENTS = `
   first: $first
   skip: $skip
-  orderBy: $orderBy
-  orderDirection: $orderDirection
 `
 
 export class BaseGraphAPI {


### PR DESCRIPTION
These properties are not being used and are causing the query to break due to a breaking change in the graph.
```
    {
      message: "Store error: internal constraint violated: 'orderBy' attribute must be an enum but is Null"
    }
```