### PR TITLE
fix: Items not being fetched with a user that is not a manager of a TP

### DIFF
--- a/spec/mocks/collections.ts
+++ b/spec/mocks/collections.ts
@@ -60,7 +60,6 @@ export const thirdPartyFragmentMock: ThirdPartyFragment = {
   root: 'aRoot',
   managers: [wallet.address],
   maxItems: '10',
-  totalItems: '1',
   metadata: {
     type: ThirdPartyMetadataType.THIRD_PARTY_V1,
     thirdParty: null,

--- a/src/Item/Item.service.ts
+++ b/src/Item/Item.service.ts
@@ -172,7 +172,7 @@ export class ItemService {
     }
   ): Promise<(ItemAttributes & { total_count: number })[]> {
     const thirdParties = await thirdPartyAPI.fetchThirdPartiesByManager(address)
-    const thirdPartyIds = thirdParties.map((thirdParty: any) => thirdParty.id)
+    const thirdPartyIds = thirdParties.map((thirdParty) => thirdParty.id)
 
     return Item.findItemsByAddress(address, thirdPartyIds, params)
   }

--- a/src/Item/Item.service.ts
+++ b/src/Item/Item.service.ts
@@ -172,11 +172,7 @@ export class ItemService {
     }
   ): Promise<(ItemAttributes & { total_count: number })[]> {
     const thirdParties = await thirdPartyAPI.fetchThirdPartiesByManager(address)
-    if (thirdParties.length <= 0) {
-      return []
-    }
-
-    const thirdPartyIds = thirdParties.map((thirdParty) => thirdParty.id)
+    const thirdPartyIds = thirdParties.map((thirdParty: any) => thirdParty.id)
 
     return Item.findItemsByAddress(address, thirdPartyIds, params)
   }

--- a/src/ThirdParty/ThirdParty.router.spec.ts
+++ b/src/ThirdParty/ThirdParty.router.spec.ts
@@ -30,7 +30,6 @@ describe('ThirdParty router', () => {
         root: 'aRoot',
         managers: ['0x1'],
         maxItems: '3',
-        totalItems: '2',
         metadata,
       },
       {
@@ -38,7 +37,6 @@ describe('ThirdParty router', () => {
         root: 'anotherRoot',
         managers: ['0x2', '0x3'],
         maxItems: '2',
-        totalItems: '1',
         metadata,
       },
     ]

--- a/src/ThirdParty/utils.spec.ts
+++ b/src/ThirdParty/utils.spec.ts
@@ -15,7 +15,6 @@ describe('toThirdParty', () => {
         root: 'aRoot',
         managers: ['0x1', '0x2'],
         maxItems: '1',
-        totalItems: '1',
         metadata: {
           type: ThirdPartyMetadataType.THIRD_PARTY_V1,
           thirdParty: {
@@ -34,7 +33,6 @@ describe('toThirdParty', () => {
         root: fragment.root,
         managers: fragment.managers,
         maxItems: fragment.maxItems,
-        totalItems: fragment.totalItems,
         name: name,
         description: description,
       }
@@ -51,7 +49,6 @@ describe('toThirdParty', () => {
         root: 'aRoot',
         managers: ['0x2'],
         maxItems: '2',
-        totalItems: '1',
         metadata: {
           type: ThirdPartyMetadataType.THIRD_PARTY_V1,
           thirdParty: null,
@@ -65,7 +62,6 @@ describe('toThirdParty', () => {
         root: fragment.root,
         managers: fragment.managers,
         maxItems: fragment.maxItems,
-        totalItems: fragment.totalItems,
         name: '',
         description: '',
       }

--- a/src/ethereum/api/fragments.ts
+++ b/src/ethereum/api/fragments.ts
@@ -166,7 +166,6 @@ export type ThirdPartyFragment = {
   root: string
   managers: string[]
   maxItems: string
-  totalItems: string
   metadata: ThirdPartyMetadata
 }
 

--- a/src/ethereum/api/fragments.ts
+++ b/src/ethereum/api/fragments.ts
@@ -54,7 +54,6 @@ export const thirdPartyFragment = () => gql`
     root
     managers
     maxItems
-    totalItems
     metadata {
       type
       thirdParty {


### PR DESCRIPTION
This PR fixes an issue that occurred when requesting the items of a user that wasn't a manager of a third party. The endpoint was returning `[]` for those cases.