### PR TITLE
feat: Add specific error for URN duplication cases

### DIFF
--- a/src/Collection/Collection.errors.ts
+++ b/src/Collection/Collection.errors.ts
@@ -29,6 +29,12 @@ export class AlreadyPublishedCollectionError extends Error {
   }
 }
 
+export class URNAlreadyInUseError extends Error {
+  constructor(public id: string, public urn: string, action: CollectionAction) {
+    super(`The selected URN is already being used. It can be ${action}.`)
+  }
+}
+
 export class WrongCollectionError extends Error {
   constructor(m: string, public data: Record<string, any>) {
     super(m)

--- a/src/Collection/Collection.errors.ts
+++ b/src/Collection/Collection.errors.ts
@@ -31,7 +31,9 @@ export class AlreadyPublishedCollectionError extends Error {
 
 export class URNAlreadyInUseError extends Error {
   constructor(public id: string, public urn: string, action: CollectionAction) {
-    super(`The selected URN is already being used. It can be ${action}.`)
+    super(
+      `The URN provided already belongs to a collection. The collection can't be ${action}.`
+    )
   }
 }
 

--- a/src/Collection/Collection.router.spec.ts
+++ b/src/Collection/Collection.router.spec.ts
@@ -279,9 +279,10 @@ describe('Collection router', () => {
                   ok: false,
                   data: {
                     id: dbTPCollection.id,
+                    urn: collectionToUpsert.urn,
                   },
                   error:
-                    "The third party collection already has published items. It can't be updated or inserted.",
+                    'The selected URN is already being used. It can be updated.',
                 })
               })
           })
@@ -445,7 +446,7 @@ describe('Collection router', () => {
             )
           })
 
-          it('should respond with a 409 and a message saying that the collection has already been published', () => {
+          it('should respond with a 409 and a message saying that the there is a collection with that urn already published', () => {
             return server
               .put(buildURL(url))
               .set(createAuthHeaders('put', url))
@@ -456,9 +457,10 @@ describe('Collection router', () => {
                   ok: false,
                   data: {
                     id: dbTPCollection.id,
+                    urn: collectionToUpsert.urn,
                   },
                   error:
-                    "The third party collection already has published items. It can't be updated or inserted.",
+                    'The selected URN is already being used. It can be updated or inserted.',
                 })
               })
           })

--- a/src/Collection/Collection.router.spec.ts
+++ b/src/Collection/Collection.router.spec.ts
@@ -282,7 +282,7 @@ describe('Collection router', () => {
                     urn: collectionToUpsert.urn,
                   },
                   error:
-                    'The selected URN is already being used. It can be updated.',
+                    "The URN provided already belongs to a collection. The collection can't be updated.",
                 })
               })
           })
@@ -460,7 +460,7 @@ describe('Collection router', () => {
                     urn: collectionToUpsert.urn,
                   },
                   error:
-                    'The selected URN is already being used. It can be updated or inserted.',
+                    "The URN provided already belongs to a collection. The collection can't be updated or inserted.",
                 })
               })
           })

--- a/src/Collection/Collection.router.ts
+++ b/src/Collection/Collection.router.ts
@@ -48,6 +48,7 @@ import {
   NonExistentCollectionError,
   UnauthorizedCollectionEditError,
   UnpublishedCollectionError,
+  URNAlreadyInUseError,
   WrongCollectionError,
 } from './Collection.errors'
 
@@ -487,6 +488,12 @@ export class CollectionRouter extends Router {
           error.message,
           { id: error.id },
           STATUS_CODES.locked
+        )
+      } else if (error instanceof URNAlreadyInUseError) {
+        throw new HTTPError(
+          error.message,
+          { id: error.id, urn: error.urn },
+          STATUS_CODES.conflict
         )
       } else if (error instanceof AlreadyPublishedCollectionError) {
         throw new HTTPError(

--- a/src/Collection/Collection.service.ts
+++ b/src/Collection/Collection.service.ts
@@ -52,6 +52,7 @@ import {
   WrongCollectionError,
   UnpublishedCollectionError,
   InsufficientSlotsError,
+  URNAlreadyInUseError,
 } from './Collection.errors'
 
 export class CollectionService {
@@ -409,8 +410,10 @@ export class CollectionService {
         // Check if the new URN for the collection already exists
         await this.checkIfThirdPartyCollectionURNExists(
           id,
+          collectionJSON.urn,
           collection.third_party_id!,
-          urn_suffix
+          urn_suffix,
+          CollectionAction.UPDATE
         )
       }
       if (this.isLockActive(collection.lock)) {
@@ -425,8 +428,10 @@ export class CollectionService {
       // Check if the URN for the new collection already exists
       await this.checkIfThirdPartyCollectionURNExists(
         id,
+        collectionJSON.urn,
         third_party_id,
-        urn_suffix
+        urn_suffix,
+        CollectionAction.UPSERT
       )
     }
 
@@ -609,16 +614,13 @@ export class CollectionService {
 
   private async checkIfThirdPartyCollectionURNExists(
     id: string,
+    urn: string,
     third_party_id: string,
     urn_suffix: string,
     action = CollectionAction.UPSERT
   ): Promise<void> {
     if (await Collection.isURNRepeated(id, third_party_id, urn_suffix)) {
-      throw new AlreadyPublishedCollectionError(
-        id,
-        CollectionType.THIRD_PARTY,
-        action
-      )
+      throw new URNAlreadyInUseError(id, urn, action)
     }
   }
 }

--- a/src/Item/Item.errors.ts
+++ b/src/Item/Item.errors.ts
@@ -30,7 +30,9 @@ export class ThirdPartyItemAlreadyPublishedError extends Error {
 
 export class URNAlreadyInUseError extends Error {
   constructor(public id: string, public urn: string, action: ItemAction) {
-    super(`The selected URN is already being used. It can be ${action}.`)
+    super(
+      `The URN provided already belong to another item. The item can't be ${action}.`
+    )
   }
 }
 

--- a/src/Item/Item.errors.ts
+++ b/src/Item/Item.errors.ts
@@ -28,6 +28,12 @@ export class ThirdPartyItemAlreadyPublishedError extends Error {
   }
 }
 
+export class URNAlreadyInUseError extends Error {
+  constructor(public id: string, public urn: string, action: ItemAction) {
+    super(`The selected URN is already being used. It can be ${action}.`)
+  }
+}
+
 export class DCLItemAlreadyPublishedError extends Error {
   constructor(
     public id: string,

--- a/src/Item/Item.model.ts
+++ b/src/Item/Item.model.ts
@@ -68,6 +68,24 @@ export class Item extends Model<ItemAttributes> {
         WHERE ${where}`)
   }
 
+  static async isURNRepeated(
+    id: string,
+    thirdPartyId: string,
+    urnSuffix: string
+  ): Promise<boolean> {
+    const counts = await this.query<{ count: number }>(SQL`
+    SELECT COUNT(*) as count
+      FROM ${raw(this.tableName)} items
+      JOIN ${raw(
+        Collection.tableName
+      )} collections ON items.collection_id = collections.id
+      WHERE items.id != ${id}
+        AND collections.third_party_id = ${thirdPartyId}
+        AND items.urn_suffix = ${urnSuffix}`)
+
+    return counts[0].count > 0
+  }
+
   // PAGINATED QUERIES
 
   static findItemsByAddress(

--- a/src/Item/Item.model.ts
+++ b/src/Item/Item.model.ts
@@ -73,7 +73,7 @@ export class Item extends Model<ItemAttributes> {
     thirdPartyId: string,
     urnSuffix: string
   ): Promise<boolean> {
-    const counts = await this.query<{ count: number }>(SQL`
+    const counts = await this.query<{ count: string }>(SQL`
     SELECT COUNT(*) as count
       FROM ${raw(this.tableName)} items
       JOIN ${raw(
@@ -83,7 +83,7 @@ export class Item extends Model<ItemAttributes> {
         AND collections.third_party_id = ${thirdPartyId}
         AND items.urn_suffix = ${urnSuffix}`)
 
-    return counts[0].count > 0
+    return Number(counts[0].count) > 0
   }
 
   // PAGINATED QUERIES

--- a/src/Item/Item.router.spec.ts
+++ b/src/Item/Item.router.spec.ts
@@ -1012,7 +1012,7 @@ describe('Item router', () => {
                           urn: itemToUpsert.urn!,
                         },
                         error:
-                          'The selected URN is already being used. It can be inserted.',
+                          "The URN provided already belong to another item. The item can't be inserted or updated.",
                         ok: false,
                       })
                     })
@@ -1036,7 +1036,7 @@ describe('Item router', () => {
                           urn: itemToUpsert.urn!,
                         },
                         error:
-                          'The selected URN is already being used. It can be inserted or updated.',
+                          "The URN provided already belong to another item. The item can't be inserted or updated.",
                         ok: false,
                       })
                     })
@@ -1153,7 +1153,7 @@ describe('Item router', () => {
                       urn: itemToUpsert.urn!,
                     },
                     error:
-                      'The selected URN is already being used. It can be inserted.',
+                      "The URN provided already belong to another item. The item can't be inserted.",
                     ok: false,
                   })
                 })

--- a/src/Item/Item.router.spec.ts
+++ b/src/Item/Item.router.spec.ts
@@ -999,7 +999,7 @@ describe('Item router', () => {
                 mockThirdPartyURNExists(itemToUpsert.urn!, true)
               })
 
-              it('should fail with 409 and a message saying that the item is already published', () => {
+              it('should fail with 409 and a message saying that the URN is already assigned to another item', () => {
                 return server
                   .put(buildURL(url))
                   .send({ item: itemToUpsert })
@@ -1012,7 +1012,7 @@ describe('Item router', () => {
                         urn: itemToUpsert.urn!,
                       },
                       error:
-                        "The third party item is already published. It can't be inserted or updated.",
+                        'The selected URN is already being used. It can be inserted or updated.',
                       ok: false,
                     })
                   })
@@ -1128,7 +1128,7 @@ describe('Item router', () => {
                       urn: itemToUpsert.urn!,
                     },
                     error:
-                      "The third party item is already published. It can't be inserted or updated.",
+                      "The selected URN is already being used. It can be inserted.",
                     ok: false,
                   })
                 })

--- a/src/Item/Item.router.spec.ts
+++ b/src/Item/Item.router.spec.ts
@@ -994,28 +994,53 @@ describe('Item router', () => {
             })
 
             describe('and the item is not published but the new URN is already in use', () => {
-              beforeEach(() => {
-                mockThirdPartyItemCurationExists(dbItem.id, false)
-                mockThirdPartyURNExists(itemToUpsert.urn!, true)
+              describe('if the URN is in the catalyst', () => {
+                beforeEach(() => {
+                  mockThirdPartyItemCurationExists(dbItem.id, false)
+                  mockThirdPartyURNExists(itemToUpsert.urn!, true)
+                })
+                it('should fail with 409 and a message saying that the URN is already assigned to another item', () => {
+                  return server
+                    .put(buildURL(url))
+                    .send({ item: itemToUpsert })
+                    .set(createAuthHeaders('put', url))
+                    .expect(409)
+                    .then((response: any) => {
+                      expect(response.body).toEqual({
+                        data: {
+                          id: itemToUpsert.id,
+                          urn: itemToUpsert.urn!,
+                        },
+                        error:
+                          'The selected URN is already being used. It can be inserted.',
+                        ok: false,
+                      })
+                    })
+                })
               })
 
-              it('should fail with 409 and a message saying that the URN is already assigned to another item', () => {
-                return server
-                  .put(buildURL(url))
-                  .send({ item: itemToUpsert })
-                  .set(createAuthHeaders('put', url))
-                  .expect(409)
-                  .then((response: any) => {
-                    expect(response.body).toEqual({
-                      data: {
-                        id: itemToUpsert.id,
-                        urn: itemToUpsert.urn!,
-                      },
-                      error:
-                        'The selected URN is already being used. It can be inserted or updated.',
-                      ok: false,
+              describe('if there is a db item with the same third_party_id & urn_suffix', () => {
+                beforeEach(() => {
+                  mockItem.isURNRepeated.mockResolvedValueOnce(true)
+                })
+                it('should fail with 409 and a message saying that the URN is already assigned to another item', () => {
+                  return server
+                    .put(buildURL(url))
+                    .send({ item: itemToUpsert })
+                    .set(createAuthHeaders('put', url))
+                    .expect(409)
+                    .then((response: any) => {
+                      expect(response.body).toEqual({
+                        data: {
+                          id: itemToUpsert.id,
+                          urn: itemToUpsert.urn!,
+                        },
+                        error:
+                          'The selected URN is already being used. It can be inserted or updated.',
+                        ok: false,
+                      })
                     })
-                  })
+                })
               })
             })
           })
@@ -1128,7 +1153,7 @@ describe('Item router', () => {
                       urn: itemToUpsert.urn!,
                     },
                     error:
-                      "The selected URN is already being used. It can be inserted.",
+                      'The selected URN is already being used. It can be inserted.',
                     ok: false,
                   })
                 })

--- a/src/Item/Item.router.ts
+++ b/src/Item/Item.router.ts
@@ -44,6 +44,7 @@ import {
   ThirdPartyItemAlreadyPublishedError,
   UnauthorizedToChangeToCollectionError,
   UnauthorizedToUpsertError,
+  URNAlreadyInUseError,
 } from './Item.errors'
 
 export class ItemRouter extends Router {
@@ -394,6 +395,12 @@ export class ItemRouter extends Router {
       } else if (error instanceof CollectionForItemLockedError) {
         throw new HTTPError(error.message, { id }, STATUS_CODES.locked)
       } else if (error instanceof ThirdPartyItemAlreadyPublishedError) {
+        throw new HTTPError(
+          error.message,
+          { id, urn: error.urn },
+          STATUS_CODES.conflict
+        )
+      } else if (error instanceof URNAlreadyInUseError) {
         throw new HTTPError(
           error.message,
           { id, urn: error.urn },

--- a/src/Item/Item.service.ts
+++ b/src/Item/Item.service.ts
@@ -604,7 +604,11 @@ export class ItemService {
         decodedItemURN.item_urn_suffix
       )
 
-      await this.checkIfThirdPartyItemURNExists(item.id, itemURN)
+      await this.checkIfThirdPartyItemURNExists(
+        item.id,
+        itemURN,
+        ItemAction.INSERT
+      )
     }
 
     const attributes = toDBItem({
@@ -644,7 +648,7 @@ export class ItemService {
     }
     const [wearable] = await peerAPI.fetchWearables<ThirdPartyWearable>([urn])
     if (wearable) {
-      throw new URNAlreadyInUseError(id, urn, ItemAction.INSERT)
+      throw new URNAlreadyInUseError(id, urn, action)
     }
   }
 }

--- a/src/Item/Item.service.ts
+++ b/src/Item/Item.service.ts
@@ -32,6 +32,7 @@ import {
   UnauthorizedToUpsertError,
   UnauthorizedToChangeToCollectionError,
   InvalidItemURNError,
+  URNAlreadyInUseError,
 } from './Item.errors'
 import { Item } from './Item.model'
 import {
@@ -591,7 +592,7 @@ export class ItemService {
             itemURN,
           ])
           if (wearable) {
-            throw new ThirdPartyItemAlreadyPublishedError(
+            throw new URNAlreadyInUseError(
               item.id,
               item.urn!,
               ItemAction.UPSERT
@@ -618,11 +619,7 @@ export class ItemService {
         itemURN,
       ])
       if (wearable) {
-        throw new ThirdPartyItemAlreadyPublishedError(
-          item.id,
-          itemURN,
-          ItemAction.UPSERT
-        )
+        throw new URNAlreadyInUseError(item.id, itemURN, ItemAction.INSERT)
       }
     }
 


### PR DESCRIPTION
Closes #489


### UI screenshots:

## When creating a collection with an already used URN
![image](https://user-images.githubusercontent.com/8763687/163371587-e2dbfb83-8ac5-412c-b5ed-160e99951b1f.png)


## When trying to update a collection URN with a one already used
![image](https://user-images.githubusercontent.com/8763687/163371762-5c7446f9-1379-498a-b3df-ab7df3fef21e.png)

## When updating an item and the updated URN is already used

![image](https://user-images.githubusercontent.com/8763687/163378315-667a43bd-c003-4074-9931-49b96a11199e.png)


