### PR TITLE
feat: Add pagination and filters to the /collections endpoint

### DIFF
--- a/src/Collection/Collection.model.ts
+++ b/src/Collection/Collection.model.ts
@@ -1,4 +1,7 @@
 import { Model, raw, SQL } from 'decentraland-server'
+import { DEFAULT_LIMIT } from '../Pagination/utils'
+import { CurationStatusFilter, CurationStatusSort } from '../Curation'
+import { CollectionCuration } from '../Curation/CollectionCuration'
 import { database } from '../database/database'
 import { Item } from '../Item/Item.model'
 import { CollectionAttributes } from './Collection.types'
@@ -7,16 +10,122 @@ type CollectionWithItemCount = CollectionAttributes & {
   item_count: number
 }
 
+type CollectionWithCounts = CollectionWithItemCount & {
+  collection_count: number
+}
+
+type FindCollectionParams = {
+  limit?: number
+  offset?: number
+  q?: string
+  assignee?: string
+  status?: CurationStatusFilter
+  sort?: CurationStatusSort
+  isPublished: boolean
+}
+
 export class Collection extends Model<CollectionAttributes> {
   static tableName = 'collections'
 
-  static findAll() {
-    return this.query<CollectionWithItemCount>(SQL`
-      SELECT *, (SELECT COUNT(*) FROM ${raw(
+  static getOrderByStatement(sort?: CurationStatusSort) {
+    switch (sort) {
+      case CurationStatusSort.MOST_RELEVANT:
+        return SQL`
+          ORDER BY
+            CASE WHEN(
+              collection_curations.assignee is NULL)
+            THEN 0
+            WHEN(collection_curations.assignee is NOT NULL AND collection_curations.status = ${CurationStatusFilter.PENDING})
+            THEN 1
+            WHEN(collection_curations.status = ${CurationStatusFilter.APPROVED})
+            THEN 2
+              WHEN(collection_curations.status = ${CurationStatusFilter.REJECTED})
+            THEN 3
+            ELSE 4
+          END
+        `
+      case CurationStatusSort.NAME_ASC:
+        return SQL`ORDER BY collections.name ASC`
+      case CurationStatusSort.NAME_DESC:
+        return SQL`ORDER BY collections.name DESC`
+      case CurationStatusSort.NEWEST:
+        return SQL`ORDER BY collections.created_at DESC`
+      default:
+        return SQL``
+    }
+  }
+
+  static getFindAllWhereStatement({
+    q,
+    assignee,
+    status,
+  }: Pick<FindCollectionParams, 'q' | 'assignee' | 'status'>) {
+    if (!q && !assignee && !status) {
+      return SQL``
+    }
+    const conditions = [
+      q ? SQL`collections.name LIKE '%' || ${q} || '%'` : undefined,
+      assignee ? SQL`collection_curations.assignee = ${assignee}` : undefined,
+      status
+        ? [
+            CurationStatusFilter.PENDING,
+            CurationStatusFilter.APPROVED,
+            CurationStatusFilter.REJECTED,
+          ].includes(status)
+          ? SQL`collection_curations.status = ${status}`
+          : status === CurationStatusFilter.TO_REVIEW
+          ? SQL`collection_curations.assignee is NULL`
+          : status === CurationStatusFilter.UNDER_REVIEW
+          ? SQL`collection_curations.assignee is NOT NULL AND collection_curations.status = ${CurationStatusFilter.PENDING}`
+          : SQL``
+        : undefined,
+    ].filter(Boolean)
+
+    const result = SQL`WHERE `
+    conditions.forEach((condition, index) => {
+      if (condition) {
+        result.append(condition)
+        if (conditions[index + 1]) {
+          result.append(SQL` AND `)
+        }
+      }
+    })
+
+    return result
+  }
+
+  static getPublishedJoinStatement(isPublished: boolean) {
+    return isPublished
+      ? SQL`JOIN ${raw(
+          Item.tableName
+        )} items on items.collection_id = collections.id AND items.blockchain_item_id is NOT NULL`
+      : SQL``
+  }
+
+  static findAll({
+    limit = DEFAULT_LIMIT,
+    offset = 0,
+    q,
+    assignee,
+    status,
+    sort,
+    isPublished,
+  }: FindCollectionParams) {
+    const query = SQL`
+      SELECT collections.*, COUNT(*) OVER() as collection_count, (SELECT COUNT(*) FROM ${raw(
         Item.tableName
       )} WHERE items.collection_id = collections.id) as item_count
-        FROM ${raw(this.tableName)}
-      `)
+        FROM ${raw(this.tableName)} collections
+        ${SQL`LEFT JOIN ${raw(
+          CollectionCuration.tableName
+        )} collection_curations ON collection_curations.collection_id = collections.id`}
+        ${SQL`${this.getPublishedJoinStatement(isPublished)}`}
+        ${SQL`${this.getFindAllWhereStatement({ q, assignee, status })}`}
+        ${SQL`${this.getOrderByStatement(sort)}`}
+        LIMIT ${limit}
+        OFFSET ${offset}  
+      `
+    return this.query<CollectionWithCounts>(query)
   }
 
   static findByAllByAddress(address: string) {

--- a/src/Collection/Collection.router.spec.ts
+++ b/src/Collection/Collection.router.spec.ts
@@ -849,7 +849,8 @@ describe('Collection router', () => {
               sort: undefined,
               status: undefined,
               limit,
-              offset: page - 1, // it's the offset
+              offset: page - 1, // it's the offset,
+              thirdPartyIds: [],
             })
           })
       })
@@ -909,6 +910,7 @@ describe('Collection router', () => {
               isPublished: true,
               offset: page - 1, // it's the offset
               limit,
+              thirdPartyIds: [],
             })
           })
       })
@@ -943,8 +945,9 @@ describe('Collection router', () => {
 
   describe('when retrieving the collections of an address', () => {
     beforeEach(() => {
-      ;(Collection.findByAllByAddress as jest.Mock).mockReturnValueOnce([
+      ;(Collection.findAll as jest.Mock).mockReturnValueOnce([
         dbCollection,
+        dbTPCollection,
       ])
       ;(Collection.findByContractAddresses as jest.Mock).mockReturnValueOnce([])
       ;(Collection.findByThirdPartyIds as jest.Mock).mockReturnValueOnce([

--- a/src/Collection/Collection.router.spec.ts
+++ b/src/Collection/Collection.router.spec.ts
@@ -800,33 +800,144 @@ describe('Collection router', () => {
   describe('when retrieving all the collections', () => {
     beforeEach(() => {
       ;(isCommitteeMember as jest.Mock).mockResolvedValueOnce(true)
-      ;(Collection.findAll as jest.Mock)
-        .mockResolvedValueOnce([dbCollection])
-        .mockResolvedValueOnce([])
       ;(Collection.findByContractAddresses as jest.Mock).mockResolvedValueOnce(
         []
       )
       ;(collectionAPI.fetchCollections as jest.Mock).mockResolvedValueOnce([])
       thirdPartyAPIMock.fetchThirdParties.mockResolvedValueOnce([])
-      url = `/collections`
     })
 
-    it('should respond with all the collections with the URN', () => {
-      return server
-        .get(buildURL(url))
-        .set(createAuthHeaders('get', url))
-        .expect(200)
-        .then((response: any) => {
-          expect(response.body).toEqual({
-            data: [
-              {
-                ...resultingCollectionAttributes,
-                urn: `urn:decentraland:mumbai:collections-v2:${dbCollection.contract_address}`,
+    describe('and sending pagination params', () => {
+      let page: number, limit: number
+      let baseUrl: string
+      let totalCollectionsFromDb: number
+      beforeEach(() => {
+        ;(page = 1), (limit = 3)
+        totalCollectionsFromDb = 1
+        baseUrl = '/collections'
+        url = `${baseUrl}?limit=${limit}&page=${page}`
+        ;(Collection.findAll as jest.Mock).mockResolvedValueOnce([
+          { ...dbCollection, collection_count: totalCollectionsFromDb },
+        ])
+      })
+      it('should respond with pagination data and should have call the findAll method with the params', () => {
+        return server
+          .get(buildURL(url))
+          .set(createAuthHeaders('get', baseUrl))
+          .expect(200)
+          .then((response: any) => {
+            expect(response.body).toEqual({
+              data: {
+                total: totalCollectionsFromDb,
+                pages: totalCollectionsFromDb,
+                page,
+                limit,
+                results: [
+                  {
+                    ...resultingCollectionAttributes,
+                    urn: `urn:decentraland:mumbai:collections-v2:${dbCollection.contract_address}`,
+                  },
+                ],
               },
-            ],
-            ok: true,
+
+              ok: true,
+            })
+            expect(Collection.findAll).toHaveBeenCalledWith({
+              assignee: undefined,
+              isPublished: false,
+              q: undefined,
+              sort: undefined,
+              status: undefined,
+              limit,
+              offset: page - 1, // it's the offset
+            })
           })
-        })
+      })
+    })
+
+    describe('and sending pagination params plus filtering options', () => {
+      let page: number,
+        limit: number,
+        baseUrl: string,
+        totalCollectionsFromDb: number,
+        q: string,
+        assignee: string,
+        status: string,
+        sort: string,
+        isPublished: string
+      beforeEach(() => {
+        ;(page = 1), (limit = 3)
+        assignee = '0x1234567890123456789012345678901234567890'
+        status = 'published'
+        sort = 'NAME_DESC'
+        isPublished = 'true'
+        q = 'collection name 1'
+        totalCollectionsFromDb = 1
+        baseUrl = '/collections'
+        url = `${baseUrl}?limit=${limit}&page=${page}&assignee=${assignee}&status=${status}&sort=${sort}&is_published=${isPublished}&q=${q}`
+        ;(Collection.findAll as jest.Mock).mockResolvedValueOnce([
+          { ...dbCollection, collection_count: totalCollectionsFromDb },
+        ])
+      })
+      it('should respond with pagination data and should have call the findAll method with the right params', () => {
+        return server
+          .get(buildURL(url))
+          .set(createAuthHeaders('get', baseUrl))
+          .expect(200)
+          .then((response: any) => {
+            expect(response.body).toEqual({
+              data: {
+                total: totalCollectionsFromDb,
+                pages: totalCollectionsFromDb,
+                page,
+                limit,
+                results: [
+                  {
+                    ...resultingCollectionAttributes,
+                    urn: `urn:decentraland:mumbai:collections-v2:${dbCollection.contract_address}`,
+                  },
+                ],
+              },
+
+              ok: true,
+            })
+            expect(Collection.findAll).toHaveBeenCalledWith({
+              q,
+              assignee,
+              status,
+              sort,
+              isPublished: true,
+              offset: page - 1, // it's the offset
+              limit,
+            })
+          })
+      })
+    })
+
+    describe('and not sending any pagination params ', () => {
+      beforeEach(() => {
+        url = `/collections`
+        ;(Collection.findAll as jest.Mock)
+          .mockResolvedValueOnce([dbCollection])
+          .mockResolvedValueOnce([])
+      })
+      it('should respond with all the collections with the URN and the legacy response', () => {
+        return server
+          .get(buildURL(url))
+          .set(createAuthHeaders('get', url))
+          .expect(200)
+          .then((response: any) => {
+            expect(response.body).toEqual({
+              data: [
+                {
+                  ...resultingCollectionAttributes,
+                  urn: `urn:decentraland:mumbai:collections-v2:${dbCollection.contract_address}`,
+                },
+              ],
+              ok: true,
+            })
+          })
+      })
     })
   })
 

--- a/src/Collection/Collection.service.ts
+++ b/src/Collection/Collection.service.ts
@@ -41,7 +41,11 @@ import {
   PublishCollectionResponse,
   ThirdPartyCollectionAttributes,
 } from './Collection.types'
-import { Collection } from './Collection.model'
+import {
+  Collection,
+  CollectionWithCounts,
+  FindCollectionParams,
+} from './Collection.model'
 import {
   CollectionAction,
   AlreadyPublishedCollectionError,
@@ -529,6 +533,17 @@ export class CollectionService {
     }
 
     return false
+  }
+
+  public async getCollections(
+    params: FindCollectionParams,
+    manager?: string
+  ): Promise<CollectionWithCounts[]> {
+    const thirdParties = manager
+      ? await thirdPartyAPI.fetchThirdPartiesByManager(manager)
+      : await thirdPartyAPI.fetchThirdParties()
+    const thirdPartyIds = thirdParties.map((thirdParty) => thirdParty.id)
+    return Collection.findAll({ ...params, thirdPartyIds })
   }
 
   public async getDbTPCollections(): Promise<CollectionAttributes[]> {

--- a/src/Curation/Curation.types.ts
+++ b/src/Curation/Curation.types.ts
@@ -9,6 +9,21 @@ export enum CurationStatus {
   REJECTED = 'rejected',
 }
 
+export enum CurationStatusFilter {
+  PENDING = 'pending',
+  APPROVED = 'approved',
+  REJECTED = 'rejected',
+  TO_REVIEW = 'to_review',
+  UNDER_REVIEW = 'under_review',
+}
+
+export enum CurationStatusSort {
+  MOST_RELEVANT = 'MOST_RELEVANT',
+  NEWEST = 'NEWEST',
+  NAME_DESC = 'NAME_DESC',
+  NAME_ASC = 'NAME_ASC',
+}
+
 export const patchCurationSchema = Object.freeze({
   type: 'object',
   properties: {

--- a/src/Item/Item.model.ts
+++ b/src/Item/Item.model.ts
@@ -119,21 +119,23 @@ export class Item extends Model<ItemAttributes> {
     return this.query<ItemWithTotalCount>(SQL`
       SELECT items.*, count(*) OVER() AS total_count
         FROM ${raw(this.tableName)} items
-        LEFT JOIN ${raw(
-          Collection.tableName
-        )} collections ON collections.id = items.collection_id
-        WHERE
-          (
-            collections.third_party_id = ANY(${thirdPartyIds})
-          OR
-            (items.eth_address = ${address} AND items.urn_suffix IS NULL)
-          )
         ${
-          collectionId
-            ? SQL`AND items.collection_id ${
-                collectionId === 'null' ? SQL`is NULL` : SQL`= ${collectionId}`
-              }`
-            : SQL``
+          collectionId !== 'null'
+            ? SQL`LEFT JOIN ${raw(
+                Collection.tableName
+              )} collections ON collections.id = items.collection_id
+              WHERE
+              (
+                collections.third_party_id = ANY(${thirdPartyIds})
+                  OR
+                (items.eth_address = ${address} AND items.urn_suffix IS NULL)
+              )
+                ${
+                  collectionId
+                    ? SQL`AND items.collection_id = ${collectionId}`
+                    : SQL``
+                }`
+            : SQL`WHERE items.collection_id is NULL`
         }
         LIMIT ${limit}
         OFFSET ${offset}

--- a/src/Item/Item.model.ts
+++ b/src/Item/Item.model.ts
@@ -119,11 +119,9 @@ export class Item extends Model<ItemAttributes> {
     return this.query<ItemWithTotalCount>(SQL`
       SELECT items.*, count(*) OVER() AS total_count
         FROM ${raw(this.tableName)} items
-        ${
-          collectionId !== 'null'
-            ? SQL`LEFT JOIN ${raw(
-                Collection.tableName
-              )} collections ON collections.id = items.collection_id
+        ${SQL`LEFT JOIN ${raw(
+          Collection.tableName
+        )} collections ON collections.id = items.collection_id
               WHERE
               (
                 collections.third_party_id = ANY(${thirdPartyIds})
@@ -132,11 +130,11 @@ export class Item extends Model<ItemAttributes> {
               )
                 ${
                   collectionId
-                    ? SQL`AND items.collection_id = ${collectionId}`
+                    ? collectionId !== 'null'
+                      ? SQL`AND items.collection_id = ${collectionId}`
+                      : SQL`AND items.collection_id is NULL`
                     : SQL``
-                }`
-            : SQL`WHERE items.collection_id is NULL`
-        }
+                }`}
         LIMIT ${limit}
         OFFSET ${offset}
     `)

--- a/src/ethereum/api/Bridge.ts
+++ b/src/ethereum/api/Bridge.ts
@@ -32,24 +32,6 @@ export class Bridge {
   ): Promise<CollectionAttributes[]> {
     const collections: CollectionAttributes[] = []
 
-    // const dbCollectionsByRemotes = await Collection.findByContractAddresses(
-    //   remoteCollections.map((collection) => collection.id)
-    // )
-    // const contractsAddresses = remoteCollections.map(
-    //   (collection) => collection.id
-    // )
-    // const dbCollectionsByRemotes = dbCollections.filter(
-    //   (collection) =>
-    //     collection.contract_address &&
-    //     contractsAddresses.includes(collection.contract_address)
-    // )
-
-    // // Filter collections already found on the database to avoid duplicates
-    // const allDbCollections = this.distinctById<CollectionAttributes>([
-    //   ...dbCollections,
-    //   ...dbCollectionsByRemotes,
-    // ])
-
     for (const dbCollection of dbCollections) {
       if (isTPCollection(dbCollection)) {
         collections.push(await this.consolidateTPCollection(dbCollection))

--- a/src/ethereum/api/Bridge.ts
+++ b/src/ethereum/api/Bridge.ts
@@ -20,35 +20,86 @@ import { CatalystItem, peerAPI } from './peer'
 
 export class Bridge {
   /**
-   * Takes TP collections found in the database and combines each one with the data from the last published item it has.
-   * To get the published information, it'll check the last curation made to an item each collection has, as each curation is updated *after* being uploaded to the Catalyst.
-   * If no published item is found or a non-TP collection is supplied, it'll be returned as-is.
-   * For more info on what data is merged, see `Bridge.mergeTPCollection`
-   * @param dbCollections - TP collections from the database
+   * Takes collections found in the database and combines each one with the data from the remote published (blockchain) collection counterpart
+   * If no published collection is found, it'll be returned as-is.
+   * For more info on what data is updated from the published item, see `Bridge.mergeCollection`
+   * @param dbCollections - DB standard collections
+   * @param remoteCollections - Blockchain standard collections
    */
-  static async consolidateTPCollections(
-    dbCollections: CollectionAttributes[]
+  static async consolidateAllCollections(
+    dbCollections: CollectionAttributes[],
+    remoteCollections: CollectionFragment[]
   ): Promise<CollectionAttributes[]> {
     const collections: CollectionAttributes[] = []
 
-    for (const dbCollection of dbCollections) {
-      let fullCollection: CollectionAttributes = { ...dbCollection }
+    // const dbCollectionsByRemotes = await Collection.findByContractAddresses(
+    //   remoteCollections.map((collection) => collection.id)
+    // )
+    // const contractsAddresses = remoteCollections.map(
+    //   (collection) => collection.id
+    // )
+    // const dbCollectionsByRemotes = dbCollections.filter(
+    //   (collection) =>
+    //     collection.contract_address &&
+    //     contractsAddresses.includes(collection.contract_address)
+    // )
 
+    // // Filter collections already found on the database to avoid duplicates
+    // const allDbCollections = this.distinctById<CollectionAttributes>([
+    //   ...dbCollections,
+    //   ...dbCollectionsByRemotes,
+    // ])
+
+    for (const dbCollection of dbCollections) {
       if (isTPCollection(dbCollection)) {
-        const lastItemCuration = await ItemCuration.findLastByCollectionId(
-          dbCollection.id
-        )
-        if (lastItemCuration) {
-          fullCollection = Bridge.mergeTPCollection(
-            dbCollection,
-            lastItemCuration
+        collections.push(await this.consolidateTPCollection(dbCollection))
+      } else {
+        let remoteCollection: CollectionFragment | undefined
+        if (dbCollection.contract_address !== null) {
+          const contractAddress = dbCollection.contract_address.toLowerCase()
+
+          remoteCollection = remoteCollections.find(
+            (remoteCollection) =>
+              remoteCollection.id.toLowerCase() === contractAddress
           )
         }
-      }
 
-      collections.push(fullCollection)
+        const collection = remoteCollection
+          ? Bridge.mergeCollection(dbCollection, remoteCollection)
+          : dbCollection
+
+        collections.push(collection)
+      }
     }
+
     return collections
+  }
+
+  /**
+   * Takes a TP collection found in the database and combines it with the data from the last published item it has.
+   * To get the published information, it'll check the last curation made to an item each collection has, as each curation is updated *after* being uploaded to the Catalyst.
+   * If no published item is found or a non-TP collection is supplied, it'll be returned as-is.
+   * For more info on what data is merged, see `Bridge.mergeTPCollection`
+   * @param dbCollection - TP collection from the database
+   */
+  static async consolidateTPCollection(
+    dbTPCollection: CollectionAttributes
+  ): Promise<CollectionAttributes> {
+    let fullCollection: CollectionAttributes = { ...dbTPCollection }
+
+    if (isTPCollection(dbTPCollection)) {
+      const lastItemCuration = await ItemCuration.findLastByCollectionId(
+        dbTPCollection.id
+      )
+      if (lastItemCuration) {
+        fullCollection = Bridge.mergeTPCollection(
+          dbTPCollection,
+          lastItemCuration
+        )
+      }
+    }
+
+    return fullCollection
   }
 
   /**


### PR DESCRIPTION
## Description
- Adds support for pagination params `limit` and `page`.
- Adds filters for: `assignee`, `status` , `q`, `is_published`
- Adds `sort` option to sort by `relevance`, `name_asc`, `name_desc` and `newest`


Closes #513