### PR TITLE
feat: Approve third party collection

### DIFF
--- a/src/Collection/Collection.errors.ts
+++ b/src/Collection/Collection.errors.ts
@@ -66,3 +66,9 @@ export class InsufficientSlotsError extends Error {
     super('The amount of items to publish exceeds the available slots.')
   }
 }
+
+export class IsNotCommitteeMember extends Error {
+  constructor(public address: string) {
+    super('The address does not belong to a committee member.')
+  }
+}

--- a/src/Curation/ItemCuration/ItemCuration.model.ts
+++ b/src/Curation/ItemCuration/ItemCuration.model.ts
@@ -97,4 +97,18 @@ export class ItemCuration extends Model<ItemCurationAttributes> {
     )
     return counts[0].count
   }
+
+  static async approveAllItemsOfACollection(
+    collectionId: string
+  ): Promise<void> {
+    await this.query(
+      SQL`UPDATE ${raw(this.tableName)} as item_curations SET status = ${
+        CurationStatus.APPROVED
+      } FROM ${raw(Item.tableName)}, ${raw(
+        Collection.tableName
+      )} WHERE items.id = item_curations.item_id AND items.collection_id = collections.id AND collections.id = ${collectionId} AND item_curations.status = ${
+        CurationStatus.PENDING
+      }`
+    )
+  }
 }


### PR DESCRIPTION
This PR adds a new endpoint that can only be executed by a curator to approve a third party collection.
Closes #530 
