### PR TITLE
feat: Return Merkle root on approval data

### DIFF
--- a/src/Collection/Collection.router.spec.ts
+++ b/src/Collection/Collection.router.spec.ts
@@ -34,6 +34,7 @@ import {
   ItemFragment,
   CollectionFragment,
   ReceiptFragment,
+  ThirdPartyFragment,
 } from '../ethereum/api/fragments'
 import { collectionAPI } from '../ethereum/api/collection'
 import { thirdPartyAPI } from '../ethereum/api/thirdParty'
@@ -2266,6 +2267,9 @@ describe('Collection router', () => {
             ;(SlotUsageCheque.findLastByCollectionId as jest.Mock).mockResolvedValueOnce(
               {}
             )
+            thirdPartyAPIMock.fetchThirdParty.mockResolvedValueOnce({
+              root: 'aRootValue',
+            } as ThirdPartyFragment)
             thirdPartyAPIMock.fetchReceiptById.mockResolvedValueOnce(undefined)
           })
 
@@ -2327,6 +2331,9 @@ describe('Collection router', () => {
               thirdPartyAPIMock.fetchReceiptById.mockResolvedValueOnce(
                 undefined
               )
+              thirdPartyAPIMock.fetchThirdParty.mockResolvedValueOnce({
+                root: 'aRootValue',
+              } as ThirdPartyFragment)
             })
 
             it('should return an array with the data for pending curations, indicating that the cheque was not used', () => {
@@ -2349,6 +2356,7 @@ describe('Collection router', () => {
                         [itemApprovalData[2].id]: 'Qm3rererer',
                       },
                       chequeWasConsumed: false,
+                      root: 'aRootValue',
                     },
                   })
                 })
@@ -2361,6 +2369,9 @@ describe('Collection router', () => {
                 id:
                   '0x7954b5d263d7d1298c98fa330de6a0d94952bb5f6694cab0dde144239d56dce1',
               } as ReceiptFragment)
+              thirdPartyAPIMock.fetchThirdParty.mockResolvedValueOnce({
+                root: 'aRootValue',
+              } as ThirdPartyFragment)
             })
 
             it('should return an array with the data for pending curations, indicating that the cheque was used', () => {
@@ -2383,6 +2394,7 @@ describe('Collection router', () => {
                         [itemApprovalData[2].id]: 'Qm3rererer',
                       },
                       chequeWasConsumed: true,
+                      root: 'aRootValue',
                     },
                   })
                 })

--- a/src/Collection/Collection.service.ts
+++ b/src/Collection/Collection.service.ts
@@ -477,9 +477,10 @@ export class CollectionService {
       slotUsageCheque.third_party_id
     )
 
-    const remoteCheque = await thirdPartyAPI.fetchReceiptById(
-      slotUsageCheckHash
-    )
+    const [thirdParty, remoteCheque] = await Promise.all([
+      thirdPartyAPI.fetchThirdParty(collection.third_party_id),
+      thirdPartyAPI.fetchReceiptById(slotUsageCheckHash),
+    ])
 
     return {
       cheque: {
@@ -487,6 +488,7 @@ export class CollectionService {
         salt,
         signature,
       },
+      root: thirdParty?.root ?? null,
       content_hashes,
       chequeWasConsumed: remoteCheque?.id === slotUsageCheckHash,
     }

--- a/src/Item/Item.types.ts
+++ b/src/Item/Item.types.ts
@@ -66,4 +66,5 @@ export type ItemApprovalData = {
     ItemCurationAttributes['content_hash']
   >
   chequeWasConsumed: boolean
+  root: string | null
 }


### PR DESCRIPTION
This PR returns the current Merkle root of a third party to avoid sending another request to re-approve a third party collection.
Closes #466