### PR TITLE
feat: Update Collections schema

### DIFF
--- a/migrations/1656530766392_update-collection-fields-created-at-updated-at.ts
+++ b/migrations/1656530766392_update-collection-fields-created-at-updated-at.ts
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder } from 'node-pg-migrate';
+import { Collection } from '../src/Collection'
+
+const tableName = Collection.tableName
+const columnCreatedAt = 'created_at'
+const columnUpdatedAt = 'updated_at'
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.alterColumn(tableName, columnCreatedAt, {default: pgm.func('current_timestamp')})
+  pgm.alterColumn(tableName, columnUpdatedAt, {default: pgm.func('current_timestamp')})
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.alterColumn(tableName, columnCreatedAt, {default: null})
+  pgm.alterColumn(tableName, columnUpdatedAt, {default: null})
+}

--- a/src/Collection/Collection.model.ts
+++ b/src/Collection/Collection.model.ts
@@ -292,7 +292,7 @@ export class Collection extends Model<CollectionAttributes> {
       )})
       VALUES (${database.toValuePlaceholders(collection)})
       ON CONFLICT (id)
-      DO UPDATE SET ${database.toAssignmentFields(attributes, 1)}
+      DO UPDATE SET ${database.toAssignmentFields(attributes, 1)},"updated_at" = now()
       RETURNING *, (SELECT COUNT(*) FROM ${
         Item.tableName
       } WHERE collections.id = items.collection_id) as item_count`,

--- a/src/Collection/Collection.router.spec.ts
+++ b/src/Collection/Collection.router.spec.ts
@@ -1,6 +1,7 @@
 import supertest from 'supertest'
 import { ethers } from 'ethers'
 import { v4 as uuid } from 'uuid'
+import { utils } from 'decentraland-commons'
 import {
   createAuthHeaders,
   buildURL,
@@ -115,6 +116,7 @@ describe('Collection router', () => {
     let third_party_id: string
     let urn: string
     let collectionToUpsert: FullCollection
+    let expectedCollectionToUpsert: FullCollection
 
     beforeEach(() => {
       urn_suffix = dbTPCollection.urn_suffix
@@ -187,6 +189,13 @@ describe('Collection router', () => {
         url = `/collections/${dbTPCollection.id}`
         urn = `${third_party_id}:${urn_suffix}`
         collectionToUpsert = {
+          ...utils.omit(toFullCollection(dbTPCollection), [
+            'created_at',
+            'updated_at',
+          ]),
+          urn,
+        }
+        expectedCollectionToUpsert = {
           ...toFullCollection(dbTPCollection),
           urn,
         }
@@ -370,6 +379,8 @@ describe('Collection router', () => {
             ...attributes,
             item_count: 0,
             lock: null,
+            created_at: expectedCollectionToUpsert.created_at,
+            updated_at: expectedCollectionToUpsert.updated_at,
           }))
         })
 
@@ -383,7 +394,7 @@ describe('Collection router', () => {
               expect(response.body).toEqual({
                 ok: true,
                 data: {
-                  ...convertCollectionDatesToISO(collectionToUpsert),
+                  ...convertCollectionDatesToISO(expectedCollectionToUpsert),
                   item_count: 0,
                   contract_address: null,
                 },
@@ -467,6 +478,8 @@ describe('Collection router', () => {
               ...attributes,
               item_count: 0,
               lock: null,
+              created_at: expectedCollectionToUpsert.created_at,
+              updated_at: expectedCollectionToUpsert.updated_at,
             }))
           })
 
@@ -480,7 +493,7 @@ describe('Collection router', () => {
                 expect(response.body).toEqual({
                   ok: true,
                   data: convertCollectionDatesToISO({
-                    ...collectionToUpsert,
+                    ...expectedCollectionToUpsert,
                     item_count: 0,
                   }),
                 })
@@ -709,7 +722,14 @@ describe('Collection router', () => {
       describe('and the collection is upserted', () => {
         beforeEach(() => {
           collectionToUpsert = {
-            ...toFullCollection(dbCollection),
+            ...utils.omit(toFullCollection(dbCollectionMock), [
+              'created_at',
+              'updated_at',
+            ]),
+            urn,
+          }
+          expectedCollectionToUpsert = {
+            ...toFullCollection(dbCollectionMock),
             urn,
           }
           mockOwnableCanUpsert(
@@ -727,6 +747,8 @@ describe('Collection router', () => {
             ...attributes,
             item_count: 0,
             lock: null,
+            created_at: expectedCollectionToUpsert.created_at,
+            updated_at: expectedCollectionToUpsert.updated_at,
           }))
           ;(Collection.isValidName as jest.Mock).mockResolvedValueOnce(true)
           ;(Collection.findOne as jest.Mock).mockResolvedValueOnce({
@@ -749,7 +771,7 @@ describe('Collection router', () => {
               expect(response.body).toEqual({
                 ok: true,
                 data: convertCollectionDatesToISO({
-                  ...collectionToUpsert,
+                  ...expectedCollectionToUpsert,
                   item_count: 0,
                   salt: expect.stringMatching(/0[xX][0-9a-fA-F]{64}/),
                   contract_address: expect.stringMatching(

--- a/src/Collection/Collection.schema.ts
+++ b/src/Collection/Collection.schema.ts
@@ -33,8 +33,6 @@ export const collectionSchema = Object.freeze({
     'salt',
     'contract_address',
     'reviewed_at',
-    'created_at',
-    'updated_at',
   ],
 })
 

--- a/src/Collection/utils.ts
+++ b/src/Collection/utils.ts
@@ -67,7 +67,7 @@ export function toDBCollection(
   let salt = isTP ? '' : collection.salt
 
   return {
-    ...utils.omit(collection, ['urn', 'lock']),
+    ...utils.omit(collection, ['urn', 'lock', 'created_at', 'updated_at']),
     urn_suffix,
     eth_address,
     contract_address,


### PR DESCRIPTION
This PR removes the fields created_at and updated_at from required at CollectionSchema and be updated at the DB level.

