### PR TITLE
feat: Filter collections using the request param isPublished

### DIFF
--- a/src/Collection/Collection.model.ts
+++ b/src/Collection/Collection.model.ts
@@ -122,28 +122,27 @@ export class Collection extends Model<CollectionAttributes> {
   static getPublishedJoinStatement(isPublished: boolean | undefined) {
     return isPublished !== undefined
       ? SQL`
-            JOIN ${raw(Item.tableName)} items ON items.collection_id = c.id ${
-          isPublished
-            ? SQL`AND (
-              (items.blockchain_item_id is NOT NULL AND c.third_party_id IS NULL)
-              OR c.third_party_id is NOT NULL)`
-            : SQL`AND (items.blockchain_item_id is NULL AND c.third_party_id IS NULL)`
-        }
-            LEFT JOIN ${raw(
-              ItemCuration.tableName
-            )} item_curations ON item_curations.item_id = items.id
-            ${
-              isPublished === false
-                ? SQL`
-                  WHERE (
-                    (SELECT COUNT(*) FROM item_curations
-                      LEFT JOIN items on items.id = item_curations.item_id
-                      LEFT JOIN collections cc on cc.id = items.collection_id
-                      WHERE items.collection_id = c.id AND item_curations.item_id = items.id
-                    ) = 0)
-                `
-                : SQL``
-            }
+          LEFT JOIN ${raw(Item.tableName)} items ON items.collection_id = c.id
+          LEFT JOIN ${raw(
+            ItemCuration.tableName
+          )} item_curations ON item_curations.item_id = items.id
+          ${
+            isPublished === false
+              ? SQL`
+                WHERE (
+                  (items.blockchain_item_id is NULL AND c.third_party_id IS NULL) AND
+                  (SELECT COUNT(*) FROM item_curations
+                    LEFT JOIN items on items.id = item_curations.item_id
+                    LEFT JOIN collections cc on cc.id = items.collection_id
+                    WHERE items.collection_id = c.id AND item_curations.item_id = items.id
+                  ) = 0)
+              `
+              : SQL`
+                WHERE (
+                  (items.blockchain_item_id is NOT NULL AND c.third_party_id IS NULL)
+                  OR c.third_party_id is NOT NULL))
+              `
+          }
         `
       : SQL``
   }

--- a/src/Collection/Collection.router.spec.ts
+++ b/src/Collection/Collection.router.spec.ts
@@ -904,7 +904,7 @@ describe('Collection router', () => {
         q = 'collection name 1'
         totalCollectionsFromDb = 1
         baseUrl = '/collections'
-        url = `${baseUrl}?limit=${limit}&page=${page}&assignee=${assignee}&status=${status}&sort=${sort}&is_published=${isPublished}&q=${q}`
+        url = `${baseUrl}?limit=${limit}&page=${page}&assignee=${assignee}&status=${status}&sort=${sort}&isPublished=${isPublished}&q=${q}`
         ;(Collection.findAll as jest.Mock).mockResolvedValueOnce([
           { ...dbCollection, collection_count: totalCollectionsFromDb },
         ])
@@ -975,59 +975,120 @@ describe('Collection router', () => {
 
   describe('when retrieving the collections of an address', () => {
     beforeEach(() => {
-      ;(Collection.findAll as jest.Mock).mockReturnValueOnce([
-        dbCollection,
-        dbTPCollection,
-      ])
-      ;(Collection.findByContractAddresses as jest.Mock).mockReturnValueOnce([])
-      ;(Collection.findByThirdPartyIds as jest.Mock).mockReturnValueOnce([
-        dbTPCollection,
-      ])
       ;(collectionAPI.fetchCollectionsByAuthorizedUser as jest.Mock).mockReturnValueOnce(
         []
       )
-      ;(thirdPartyAPI.fetchThirdPartiesByManager as jest.Mock).mockReturnValueOnce(
-        [{ id: dbTPCollection.third_party_id }]
-      )
-      ;(ItemCuration.findLastByCollectionId as jest.Mock).mockReturnValueOnce(
-        itemCurationMock
-      )
-      mockThirdPartyCollectionIsPublished(dbTPCollection.id, false)
+      ;(collectionAPI.fetchCollections as jest.Mock).mockResolvedValueOnce([])
       url = `/${wallet.address}/collections`
     })
 
-    it('should return the requested collections with the URN', () => {
-      return server
-        .get(buildURL(url))
-        .set(createAuthHeaders('get', url))
-        .expect(200)
-        .then((response: any) => {
-          expect(Collection.findAll).toHaveBeenCalledWith({
-            address: wallet.address,
-            limit: undefined,
-            offset: undefined,
-            sort: CurationStatusSort.NEWEST,
-            thirdPartyIds: [dbTPCollection.third_party_id],
-            remoteIds: [],
-          })
-          expect(response.body).toEqual({
-            data: [
-              {
-                ...resultingCollectionAttributes,
-                urn: `urn:decentraland:mumbai:collections-v2:${dbCollection.contract_address}`,
+    describe('sending pagination params plus filtering options', () => {
+      let page: number,
+        limit: number,
+        isPublished: string,
+        totalCollectionsFromDb: number
+      beforeEach(() => {
+          page = 1, 
+          limit = 3,
+          isPublished = 'true',
+          totalCollectionsFromDb = 1
+        ;(Collection.findAll as jest.Mock).mockReturnValueOnce([
+          { ...dbCollection, collection_count: totalCollectionsFromDb },
+        ])
+        ;(Collection.findByThirdPartyIds as jest.Mock).mockReturnValueOnce(
+          []
+        )
+        ;(thirdPartyAPI.fetchThirdPartiesByManager as jest.Mock).mockReturnValueOnce(
+          []
+        )
+      })
+
+      it('should respond with pagination data and should have call the findAll method with the right params', () => {
+        return server
+          .get(buildURL(`${url}?limit=${limit}&page=${page}&isPublished=${isPublished}`))
+          .set(createAuthHeaders('get', url))
+          .expect(200)
+          .then((response: any) => {
+            expect(response.body).toEqual({
+              data: {
+                total: totalCollectionsFromDb,
+                pages: totalCollectionsFromDb,
+                page,
+                limit,
+                results: [
+                  {
+                    ...resultingCollectionAttributes,
+                    urn: `urn:decentraland:mumbai:collections-v2:${dbCollection.contract_address}`,
+                  },
+                ],
               },
-              {
-                ...toResultCollection(dbTPCollection),
-                is_published: true,
-                urn: `${dbTPCollection.third_party_id}:${dbTPCollection.urn_suffix}`,
-                reviewed_at: itemCurationMock.updated_at.toISOString(),
-                created_at: itemCurationMock.created_at.toISOString(),
-                updated_at: itemCurationMock.updated_at.toISOString(),
-              },
-            ],
-            ok: true,
+
+              ok: true,
+            })
+            expect(Collection.findAll).toHaveBeenCalledWith({
+              address: wallet.address,
+              limit,
+              offset: page - 1,
+              sort: CurationStatusSort.NEWEST,
+              isPublished: true,
+              thirdPartyIds: [],
+              remoteIds: [],
+            })
           })
-        })
+      })
+    })
+
+    describe('and not sending any pagination params ', () => {
+      beforeEach(() => {
+        ;(Collection.findAll as jest.Mock).mockReturnValueOnce([
+          dbCollection,
+          dbTPCollection,
+        ])
+        ;(Collection.findByThirdPartyIds as jest.Mock).mockReturnValueOnce([
+          dbTPCollection,
+        ])
+        ;(thirdPartyAPI.fetchThirdPartiesByManager as jest.Mock).mockReturnValueOnce(
+          [{ id: dbTPCollection.third_party_id }]
+        )
+        ;(ItemCuration.findLastByCollectionId as jest.Mock).mockReturnValueOnce(
+          itemCurationMock
+        )
+        mockThirdPartyCollectionIsPublished(dbTPCollection.id, false)
+      })
+
+      it('should return the requested collections with the URN', () => {
+        return server
+          .get(buildURL(url))
+          .set(createAuthHeaders('get', url))
+          .expect(200)
+          .then((response: any) => {
+            expect(Collection.findAll).toHaveBeenCalledWith({
+              address: wallet.address,
+              limit: undefined,
+              offset: undefined,
+              sort: CurationStatusSort.NEWEST,
+              thirdPartyIds: [dbTPCollection.third_party_id],
+              remoteIds: [],
+            })
+            expect(response.body).toEqual({
+              data: [
+                {
+                  ...resultingCollectionAttributes,
+                  urn: `urn:decentraland:mumbai:collections-v2:${dbCollection.contract_address}`,
+                },
+                {
+                  ...toResultCollection(dbTPCollection),
+                  is_published: true,
+                  urn: `${dbTPCollection.third_party_id}:${dbTPCollection.urn_suffix}`,
+                  reviewed_at: itemCurationMock.updated_at.toISOString(),
+                  created_at: itemCurationMock.created_at.toISOString(),
+                  updated_at: itemCurationMock.updated_at.toISOString(),
+                },
+              ],
+              ok: true,
+            })
+          })
+      })
     })
   })
 

--- a/src/Collection/Collection.router.spec.ts
+++ b/src/Collection/Collection.router.spec.ts
@@ -904,7 +904,7 @@ describe('Collection router', () => {
         q = 'collection name 1'
         totalCollectionsFromDb = 1
         baseUrl = '/collections'
-        url = `${baseUrl}?limit=${limit}&page=${page}&assignee=${assignee}&status=${status}&sort=${sort}&isPublished=${isPublished}&q=${q}`
+        url = `${baseUrl}?limit=${limit}&page=${page}&assignee=${assignee}&status=${status}&sort=${sort}&is_published=${isPublished}&q=${q}`
         ;(Collection.findAll as jest.Mock).mockResolvedValueOnce([
           { ...dbCollection, collection_count: totalCollectionsFromDb },
         ])
@@ -1005,7 +1005,7 @@ describe('Collection router', () => {
 
       it('should respond with pagination data and should have call the findAll method with the right params', () => {
         return server
-          .get(buildURL(`${url}?limit=${limit}&page=${page}&isPublished=${isPublished}`))
+          .get(buildURL(`${url}?limit=${limit}&page=${page}&is_published=${isPublished}`))
           .set(createAuthHeaders('get', url))
           .expect(200)
           .then((response: any) => {

--- a/src/Collection/Collection.router.ts
+++ b/src/Collection/Collection.router.ts
@@ -221,7 +221,7 @@ export class CollectionRouter extends Router {
     req: AuthRequest
   ): Promise<PaginatedResponse<FullCollection> | FullCollection[]> => {
     const { page, limit } = getPaginationParams(req)
-    const { assignee, status, sort, q, isPublished } = req.query
+    const { assignee, status, sort, q, is_published } = req.query
     const eth_address = req.auth.ethAddress
     const canRequestCollections = await isCommitteeMember(eth_address)
 
@@ -244,7 +244,7 @@ export class CollectionRouter extends Router {
       assignee: assignee as string,
       status: status as CurationStatusFilter,
       sort: sort as CurationStatusSort,
-      isPublished: isPublished ? isPublished === 'true' : undefined,
+      isPublished: is_published ? is_published === 'true' : undefined,
       offset: page && limit ? getOffset(page, limit) : undefined,
       limit,
       remoteIds: status
@@ -274,7 +274,7 @@ export class CollectionRouter extends Router {
     req: AuthRequest
   ): Promise<PaginatedResponse<FullCollection> | FullCollection[]> => {
     const { page, limit } = getPaginationParams(req)
-    const { isPublished } = req.query
+    const { is_published } = req.query
     const eth_address = server.extractFromReq(req, 'address')
     const auth_address = req.auth.ethAddress
 
@@ -296,7 +296,7 @@ export class CollectionRouter extends Router {
         limit,
         address: eth_address,
         sort: CurationStatusSort.NEWEST,
-        isPublished: isPublished ? isPublished === 'true' : undefined,
+        isPublished: is_published ? is_published === 'true' : undefined,
         remoteIds: authorizedRemoteCollections.map(
           (remoteCollection) => remoteCollection.id
         ),


### PR DESCRIPTION
This PR allows filtering the collections of an address by using the request param: `isPublished`