### PR TITLE
fix: Force download thumbnails using cacheblock

### DIFF
--- a/src/S3/S3Router.ts
+++ b/src/S3/S3Router.ts
@@ -26,14 +26,21 @@ export class S3Router extends Router {
     this.router.head('/storage/contents/:filename', this.handleContents)
   }
 
-  private buildRedirectUrl(model: S3Model, filename: string) {
-    return `${getBucketURL()}/${model.getFileKey(filename)}`
+  private buildRedirectUrl(
+    model: S3Model,
+    filename: string,
+    cacheblock: boolean = false
+  ) {
+    return `${getBucketURL()}/${model.getFileKey(filename)}${
+      cacheblock ? '?cacheblock=true' : ''
+    }`
   }
 
   private permanentlyRedirectFile(req: Request, res: Response, model: S3Model) {
     const filename = server.extractFromReq(req, 'filename')
+    const cacheblock = req.query.cacheblock === 'true'
     addInmutableCacheControlHeader(res)
-    return res.redirect(this.buildRedirectUrl(model, filename), 301)
+    return res.redirect(this.buildRedirectUrl(model, filename, cacheblock), 301)
   }
 
   private handleAssetPacks = (req: Request, res: Response) => {

--- a/src/S3/S3Router.ts
+++ b/src/S3/S3Router.ts
@@ -29,18 +29,19 @@ export class S3Router extends Router {
   private buildRedirectUrl(
     model: S3Model,
     filename: string,
-    cacheblock: boolean = false
+    ts: string | undefined
   ) {
     return `${getBucketURL()}/${model.getFileKey(filename)}${
-      cacheblock ? '?cacheblock=true' : ''
+      ts ? `?ts=${ts}` : ''
     }`
   }
 
   private permanentlyRedirectFile(req: Request, res: Response, model: S3Model) {
     const filename = server.extractFromReq(req, 'filename')
-    const cacheblock = req.query.cacheblock === 'true'
+    // This param is to avoid cache misbehavior and force to download the file.
+    const ts = req.query.ts as string
     addInmutableCacheControlHeader(res)
-    return res.redirect(this.buildRedirectUrl(model, filename, cacheblock), 301)
+    return res.redirect(this.buildRedirectUrl(model, filename, ts), 301)
   }
 
   private handleAssetPacks = (req: Request, res: Response) => {


### PR DESCRIPTION
This fix forces the download of the S3 items when passing the query param `ts`

Closes #2328