### PR TITLE
chore: remove support for legacy emotes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -555,9 +555,9 @@
       }
     },
     "@dcl/schemas": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.8.1.tgz",
-      "integrity": "sha512-aBn5P8aaMGedvY0zj80lIpKC+dB+OXwH6zrYjHXSyftvKrMFkdKmu4Mx2yhppjvgBO/yxr7d+rlmeAkjr95dDQ==",
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.18.1.tgz",
+      "integrity": "sha512-u5F9STn8qSKGfjNp2R70muQ9Oi6dKWxWwcxNX0rINauDd4jSyEhnUtXcJlw0gmNupORupUtXVaB436Xjnok2Xw==",
       "requires": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@apollo/client": "^3.3.9",
     "@dcl/crypto": "^3.0.1",
     "@dcl/hashing": "^1.1.0",
-    "@dcl/schemas": "^5.8.0",
+    "@dcl/schemas": "^5.18.1",
     "@ethersproject/solidity": "^5.0.9",
     "@types/escape-html": "0.0.20",
     "@types/express": "^4.17.11",
@@ -79,9 +79,9 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@types/interface-datastore": "^1.0.0",
     "@swc/core": "^1.2.102",
     "@swc/jest": "^0.2.22",
+    "@types/interface-datastore": "^1.0.0",
     "@types/isomorphic-fetch": "0.0.35",
     "@types/jest": "^27.0.1",
     "@types/multer-s3": "^2.7.9",

--- a/src/Item/hashes.ts
+++ b/src/Item/hashes.ts
@@ -26,14 +26,14 @@ const ANIMATION_EMPTY_METRICS = {
 function buildStandardWearableEntityMetadata(
   item: ItemAttributes,
   collection: CollectionAttributes
-): Wearable & { emoteDataV0?: { loop: boolean } } {
+): Wearable {
   if (!isStandardItemPublished(item, collection)) {
     throw new Error(
       "The item's collection must be published to build its metadata"
     )
   }
 
-  const entity: Wearable & { emoteDataV0?: { loop: boolean } } = {
+  const entity: Wearable = {
     id: getDecentralandItemURN(item, collection.contract_address!),
     name: item.name,
     description: item.description,


### PR DESCRIPTION
This PR removes a static type property that wasn't used anymore `emoteDataV0` and upgrades the common schemas to the latest version.