### PR TITLE
feat: Get collection addresses

### DIFF
--- a/src/Collection/Collection.model.ts
+++ b/src/Collection/Collection.model.ts
@@ -26,6 +26,7 @@ export type FindCollectionParams = {
   sort?: CurationStatusSort
   isPublished?: boolean
   remoteIds?: CollectionAttributes['id'][]
+  itemTags?: string[]
 }
 
 export class Collection extends Model<CollectionAttributes> {
@@ -71,9 +72,16 @@ export class Collection extends Model<CollectionAttributes> {
     address,
     thirdPartyIds,
     remoteIds,
+    itemTags,
   }: Pick<
     FindCollectionParams,
-    'q' | 'assignee' | 'status' | 'address' | 'thirdPartyIds' | 'remoteIds'
+    | 'q'
+    | 'assignee'
+    | 'status'
+    | 'address'
+    | 'thirdPartyIds'
+    | 'remoteIds'
+    | 'itemTags'
   >) {
     if (!q && !assignee && !status && !address && !thirdPartyIds?.length) {
       return SQL``
@@ -99,6 +107,9 @@ export class Collection extends Model<CollectionAttributes> {
           : status === CurationStatusFilter.UNDER_REVIEW // Under review: isApproved false from the contract OR it's assigned & has pending curation
           ? SQL`collection_curations.assignee is NOT NULL AND collection_curations.status = ${CurationStatusFilter.PENDING}`
           : SQL``
+        : undefined,
+      itemTags
+        ? SQL`(items.data::json->'tags')::jsonb ? ANY(${itemTags})`
         : undefined,
     ].filter(Boolean)
 
@@ -188,6 +199,13 @@ export class Collection extends Model<CollectionAttributes> {
           )} cc ORDER BY cc.collection_id, cc.created_at DESC) collection_curations 
           ON collection_curations.collection_id = collections.id
         `}
+        ${
+          whereFilters.itemTags
+            ? SQL`LEFT JOIN ${raw(
+                Item.tableName
+              )} items ON collections.id = items.collection_id`
+            : SQL``
+        }
         ${SQL`${this.getFindAllWhereStatement(whereFilters)}`}
         ${SQL`${this.getOrderByStatement(sort, whereFilters.remoteIds)}`}
         LIMIT ${limit}

--- a/src/Collection/Collection.model.ts
+++ b/src/Collection/Collection.model.ts
@@ -109,7 +109,7 @@ export class Collection extends Model<CollectionAttributes> {
           : SQL``
         : undefined,
       itemTags
-        ? SQL`(items.data::json->'tags')::jsonb ? ANY(${itemTags})`
+        ? SQL`LOWER(items.data::json->>'tags')::jsonb ? ANY(${itemTags})`
         : undefined,
     ].filter(Boolean)
 

--- a/src/Collection/Collection.router.spec.ts
+++ b/src/Collection/Collection.router.spec.ts
@@ -1006,7 +1006,7 @@ describe('Collection router', () => {
               limit,
               thirdPartyIds: [],
               remoteIds: [],
-              itemTags: [itemTag, itemTag2],
+              itemTags: [itemTag.toLowerCase(), itemTag2.toLowerCase()],
             })
           })
       })
@@ -2705,7 +2705,7 @@ describe('Collection router', () => {
               limit,
               thirdPartyIds: [],
               remoteIds: [],
-              itemTags: [itemTag],
+              itemTags: [itemTag.toLowerCase()],
             })
           })
       })
@@ -2765,7 +2765,7 @@ describe('Collection router', () => {
               limit,
               thirdPartyIds: [],
               remoteIds: [],
-              itemTags: [itemTag, itemTag2],
+              itemTags: [itemTag.toLowerCase(), itemTag2.toLowerCase()],
             })
           })
       })

--- a/src/Collection/Collection.router.spec.ts
+++ b/src/Collection/Collection.router.spec.ts
@@ -941,6 +941,72 @@ describe('Collection router', () => {
               limit,
               thirdPartyIds: [],
               remoteIds: [],
+              itemTags: undefined,
+            })
+          })
+      })
+    })
+
+    describe('and sending pagination params plus filtering with array tag options', () => {
+      let page: number,
+        limit: number,
+        baseUrl: string,
+        totalCollectionsFromDb: number,
+        q: string,
+        assignee: string,
+        status: string,
+        sort: string,
+        isPublished: string,
+        itemTag: string,
+        itemTag2: string
+      beforeEach(() => {
+        ;(page = 1), (limit = 3)
+        assignee = '0x1234567890123456789012345678901234567890'
+        status = 'published'
+        sort = 'NAME_DESC'
+        isPublished = 'true'
+        q = 'collection name 1'
+        itemTag = 'TAG'
+        itemTag2 = 'TAG2'
+        totalCollectionsFromDb = 1
+        baseUrl = '/collections'
+        url = `${baseUrl}?limit=${limit}&page=${page}&assignee=${assignee}&status=${status}&sort=${sort}&is_published=${isPublished}&q=${q}&tag=${itemTag}&tag=${itemTag2}`
+        ;(Collection.findAll as jest.Mock).mockResolvedValueOnce([
+          { ...dbCollection, collection_count: totalCollectionsFromDb },
+        ])
+      })
+      it('should respond with pagination data and should have call the findAll method with the right params', () => {
+        return server
+          .get(buildURL(url))
+          .set(createAuthHeaders('get', baseUrl))
+          .expect(200)
+          .then((response: any) => {
+            expect(response.body).toEqual({
+              data: {
+                total: totalCollectionsFromDb,
+                pages: totalCollectionsFromDb,
+                page,
+                limit,
+                results: [
+                  {
+                    ...resultingCollectionAttributes,
+                    urn: `urn:decentraland:mumbai:collections-v2:${dbCollection.contract_address}`,
+                  },
+                ],
+              },
+              ok: true,
+            })
+            expect(Collection.findAll).toHaveBeenCalledWith({
+              q,
+              assignee,
+              status,
+              sort,
+              isPublished: true,
+              offset: page - 1, // it's the offset
+              limit,
+              thirdPartyIds: [],
+              remoteIds: [],
+              itemTags: [itemTag, itemTag2],
             })
           })
       })
@@ -2526,6 +2592,201 @@ describe('Collection router', () => {
                 id: dbCollection.id,
               },
               error: 'Collection is not Third Party',
+            })
+          })
+      })
+    })
+  })
+
+  describe('when retrieving all the collections addresses', () => {
+    beforeEach(() => {
+      ;(isCommitteeMember as jest.Mock).mockResolvedValueOnce(true)
+      ;(Collection.findByContractAddresses as jest.Mock).mockResolvedValueOnce(
+        []
+      )
+      ;(collectionAPI.fetchCollections as jest.Mock).mockResolvedValueOnce([])
+      thirdPartyAPIMock.fetchThirdParties.mockResolvedValueOnce([])
+    })
+
+    describe('and sending pagination params', () => {
+      let page: number, limit: number
+      let baseUrl: string
+      let totalCollectionsFromDb: number
+      beforeEach(() => {
+        ;(page = 1), (limit = 3)
+        totalCollectionsFromDb = 1
+        baseUrl = '/addresses'
+        url = `${baseUrl}?limit=${limit}&page=${page}`
+        ;(Collection.findAll as jest.Mock).mockResolvedValueOnce([
+          { ...dbCollection, collection_count: totalCollectionsFromDb },
+        ])
+      })
+      it('should respond with pagination data and should have call the findAll method with the params', () => {
+        return server
+          .get(buildURL(url))
+          .set(createAuthHeaders('get', baseUrl))
+          .expect(200)
+          .then((response: any) => {
+            expect(response.body).toEqual({
+              data: {
+                total: totalCollectionsFromDb,
+                pages: totalCollectionsFromDb,
+                page,
+                limit,
+                results: [resultingCollectionAttributes.contract_address],
+              },
+              ok: true,
+            })
+            expect(Collection.findAll).toHaveBeenCalledWith({
+              assignee: undefined,
+              isPublished: undefined,
+              q: undefined,
+              sort: undefined,
+              status: undefined,
+              limit,
+              offset: page - 1, // it's the offset,
+              thirdPartyIds: [],
+              remoteIds: [],
+              itemTags: undefined,
+            })
+          })
+      })
+    })
+
+    describe('and sending pagination params plus filtering options', () => {
+      let page: number,
+        limit: number,
+        baseUrl: string,
+        totalCollectionsFromDb: number,
+        q: string,
+        assignee: string,
+        status: string,
+        sort: string,
+        isPublished: string,
+        itemTag: string
+      beforeEach(() => {
+        ;(page = 1), (limit = 3)
+        assignee = '0x1234567890123456789012345678901234567890'
+        status = 'published'
+        sort = 'NAME_DESC'
+        isPublished = 'true'
+        q = 'collection name 1'
+        itemTag = 'TAG'
+        totalCollectionsFromDb = 1
+        baseUrl = '/addresses'
+        url = `${baseUrl}?limit=${limit}&page=${page}&assignee=${assignee}&status=${status}&sort=${sort}&is_published=${isPublished}&q=${q}&tag=${itemTag}`
+        ;(Collection.findAll as jest.Mock).mockResolvedValueOnce([
+          { ...dbCollection, collection_count: totalCollectionsFromDb },
+        ])
+      })
+      it('should respond with pagination data and should have call the findAll method with the right params', () => {
+        return server
+          .get(buildURL(url))
+          .set(createAuthHeaders('get', baseUrl))
+          .expect(200)
+          .then((response: any) => {
+            expect(response.body).toEqual({
+              data: {
+                total: totalCollectionsFromDb,
+                pages: totalCollectionsFromDb,
+                page,
+                limit,
+                results: [resultingCollectionAttributes.contract_address],
+              },
+              ok: true,
+            })
+            expect(Collection.findAll).toHaveBeenCalledWith({
+              q,
+              assignee,
+              status,
+              sort,
+              isPublished: true,
+              offset: page - 1, // it's the offset
+              limit,
+              thirdPartyIds: [],
+              remoteIds: [],
+              itemTags: [itemTag],
+            })
+          })
+      })
+    })
+
+    describe('and sending pagination params plus filtering with array tag options', () => {
+      let page: number,
+        limit: number,
+        baseUrl: string,
+        totalCollectionsFromDb: number,
+        q: string,
+        assignee: string,
+        status: string,
+        sort: string,
+        isPublished: string,
+        itemTag: string,
+        itemTag2: string
+      beforeEach(() => {
+        ;(page = 1), (limit = 3)
+        assignee = '0x1234567890123456789012345678901234567890'
+        status = 'published'
+        sort = 'NAME_DESC'
+        isPublished = 'true'
+        q = 'collection name 1'
+        itemTag = 'TAG'
+        itemTag2 = 'TAG2'
+        totalCollectionsFromDb = 1
+        baseUrl = '/addresses'
+        url = `${baseUrl}?limit=${limit}&page=${page}&assignee=${assignee}&status=${status}&sort=${sort}&is_published=${isPublished}&q=${q}&tag=${itemTag}&tag=${itemTag2}`
+        ;(Collection.findAll as jest.Mock).mockResolvedValueOnce([
+          { ...dbCollection, collection_count: totalCollectionsFromDb },
+        ])
+      })
+      it('should respond with pagination data and should have call the findAll method with the right params', () => {
+        return server
+          .get(buildURL(url))
+          .set(createAuthHeaders('get', baseUrl))
+          .expect(200)
+          .then((response: any) => {
+            expect(response.body).toEqual({
+              data: {
+                total: totalCollectionsFromDb,
+                pages: totalCollectionsFromDb,
+                page,
+                limit,
+                results: [resultingCollectionAttributes.contract_address],
+              },
+              ok: true,
+            })
+            expect(Collection.findAll).toHaveBeenCalledWith({
+              q,
+              assignee,
+              status,
+              sort,
+              isPublished: true,
+              offset: page - 1, // it's the offset
+              limit,
+              thirdPartyIds: [],
+              remoteIds: [],
+              itemTags: [itemTag, itemTag2],
+            })
+          })
+      })
+    })
+
+    describe('and not sending any pagination params ', () => {
+      beforeEach(() => {
+        url = `/addresses`
+        ;(Collection.findAll as jest.Mock)
+          .mockResolvedValueOnce([dbCollection])
+          .mockResolvedValueOnce([])
+      })
+      it('should respond with all the collections addresses', () => {
+        return server
+          .get(buildURL(url))
+          .set(createAuthHeaders('get', url))
+          .expect(200)
+          .then((response: any) => {
+            expect(response.body).toEqual({
+              data: [resultingCollectionAttributes.contract_address],
+              ok: true,
             })
           })
       })

--- a/src/Collection/Collection.router.ts
+++ b/src/Collection/Collection.router.ts
@@ -263,8 +263,8 @@ export class CollectionRouter extends Router {
           remoteCollections.filter((r) => !r.isApproved).map((c) => c.id),
       itemTags: tag
         ? Array.isArray(tag)
-          ? (tag as string[])
-          : [tag as string]
+          ? (tag as string[]).map((t) => t.toLowerCase())
+          : [(tag as string).toLowerCase()]
         : undefined,
     })
 
@@ -624,8 +624,8 @@ export class CollectionRouter extends Router {
           remoteCollections.filter((r) => !r.isApproved).map((c) => c.id),
       itemTags: tag
         ? Array.isArray(tag)
-          ? (tag as string[])
-          : [tag as string]
+          ? (tag as string[]).map((t) => t.toLowerCase())
+          : [(tag as string).toLowerCase()]
         : undefined,
     })
 


### PR DESCRIPTION
This PR allows getting the collections addresses using params and adds the new param filter `tag` to filter collections by item tags.

Closes #607
Closes #608