### PR TITLE
fix: Manager cannot upsert items

### DIFF
--- a/src/Collection/Collection.service.ts
+++ b/src/Collection/Collection.service.ts
@@ -532,6 +532,21 @@ export class CollectionService {
     return !!remoteCollection
   }
 
+  public async isDCLManager(
+    id: string,
+    ethAddress: string
+  ): Promise<boolean> {
+    const collection = await this.getCollection(id)
+
+    if (collection) {
+      return collection.managers.some(
+        manager => manager === ethAddress
+      )
+    }
+
+    return false
+  }
+
   public async isOwnedOrManagedBy(
     id: string,
     ethAddress: string

--- a/src/Item/Item.router.spec.ts
+++ b/src/Item/Item.router.spec.ts
@@ -1617,6 +1617,12 @@ describe('Item router', () => {
         describe('and the item is being inserted', () => {
           beforeEach(() => {
             mockItem.findOne.mockResolvedValueOnce(undefined)
+            mockCollection.findByIds.mockResolvedValueOnce([
+              {
+                ...dbCollectionMock,
+                item_count: 1,
+              },
+            ])
             ;(collectionAPI.fetchCollection as jest.Mock).mockReset()
             ;(collectionAPI.fetchCollection as jest.Mock).mockImplementationOnce(
               () => Promise.resolve(itemFragment.collection)
@@ -1631,7 +1637,7 @@ describe('Item router', () => {
               .expect(STATUS_CODES.conflict)
 
             expect(mockItem.findOne).toHaveBeenCalledTimes(1)
-            expect(mockCollection.findByIds).toHaveBeenCalledTimes(1)
+            expect(mockCollection.findByIds).toHaveBeenCalledTimes(2)
 
             expect(response.body).toEqual({
               data: { id: itemToUpsert.id },
@@ -1660,6 +1666,12 @@ describe('Item router', () => {
               })
             )
             mockItem.findOne.mockResolvedValueOnce(dbItem)
+            mockCollection.findByIds.mockResolvedValueOnce([
+              {
+                ...dbCollectionMock,
+                item_count: 1,
+              },
+            ])
             ;(collectionAPI.fetchCollection as jest.Mock).mockReset()
             ;(collectionAPI.fetchCollection as jest.Mock).mockImplementationOnce(
               () =>
@@ -1683,7 +1695,7 @@ describe('Item router', () => {
               .expect(STATUS_CODES.ok)
 
             expect(mockItem.findOne).toHaveBeenCalledTimes(1)
-            expect(mockCollection.findByIds).toHaveBeenCalledTimes(1)
+            expect(mockCollection.findByIds).toHaveBeenCalledTimes(2)
             expect(response.body).toEqual({
               data: {
                 ...Bridge.toFullItem(dbItem),
@@ -1704,6 +1716,12 @@ describe('Item router', () => {
               ...itemToUpsert,
               collection_id: null,
             })
+            mockCollection.findByIds.mockResolvedValueOnce([
+              {
+                ...dbCollectionMock,
+                item_count: 1,
+              },
+            ])
             ;(collectionAPI.fetchCollection as jest.Mock).mockReset()
             ;(collectionAPI.fetchCollection as jest.Mock).mockImplementationOnce(
               () => Promise.resolve(itemFragment.collection)
@@ -1731,6 +1749,12 @@ describe('Item router', () => {
         describe('and the item is being removed from the collection', () => {
           beforeEach(() => {
             mockItem.findOne.mockResolvedValueOnce(itemToUpsert)
+            mockCollection.findByIds.mockResolvedValueOnce([
+              {
+                ...dbCollectionMock,
+                item_count: 1,
+              },
+            ])
             ;(collectionAPI.fetchCollection as jest.Mock).mockReset()
             ;(collectionAPI.fetchCollection as jest.Mock).mockImplementationOnce(
               () => Promise.resolve(itemFragment.collection)
@@ -1756,6 +1780,12 @@ describe('Item router', () => {
         describe("and the item's rarity is being changed", () => {
           beforeEach(() => {
             mockItem.findOne.mockResolvedValueOnce(dbItem)
+            mockCollection.findByIds.mockResolvedValueOnce([
+              {
+                ...dbCollectionMock,
+                item_count: 1,
+              },
+            ])
             ;(collectionAPI.fetchCollection as jest.Mock).mockReset()
             ;(collectionAPI.fetchCollection as jest.Mock).mockImplementationOnce(
               () => Promise.resolve(itemFragment.collection)
@@ -1794,6 +1824,12 @@ describe('Item router', () => {
               })
             )
             mockItem.findOne.mockResolvedValueOnce(dbItem)
+            mockCollection.findByIds.mockResolvedValueOnce([
+              {
+                ...dbCollectionMock,
+                item_count: 1,
+              },
+            ])
             ;(collectionAPI.fetchCollection as jest.Mock).mockReset()
             ;(collectionAPI.fetchCollection as jest.Mock).mockImplementationOnce(
               () => Promise.resolve(itemFragment.collection)

--- a/src/Item/Item.service.ts
+++ b/src/Item/Item.service.ts
@@ -423,7 +423,25 @@ export class ItemService {
     dbCollection: CollectionAttributes | undefined,
     eth_address: string
   ): Promise<FullItem> {
-    const canUpsert = await new Ownable(Item).canUpsert(item.id, eth_address)
+    let isManager = false
+    const isDbCollectionPublished =
+      dbCollection &&
+      (await this.collectionService.isDCLPublished(
+        dbCollection.contract_address!
+      ))
+
+    if (isDbCollectionPublished) {
+      const remoteCollection = await collectionAPI.fetchCollection(
+        dbCollection.contract_address!
+      )
+
+      isManager = remoteCollection!.managers.some(
+        manager => manager === eth_address
+      )
+    }
+
+    const canUpsert =
+      (await new Ownable(Item).canUpsert(item.id, eth_address)) || isManager
     if (!canUpsert) {
       throw new UnauthorizedToUpsertError(item.id, eth_address)
     }
@@ -433,19 +451,13 @@ export class ItemService {
         dbCollection.eth_address.toLowerCase() !== eth_address
 
       // Prohibits adding an item to a collection that is not owned by the user
-      if (isCollectionOwnerDifferent) {
+      if (isCollectionOwnerDifferent && !isManager) {
         throw new UnauthorizedToChangeToCollectionError(
           item.id,
           eth_address,
           item.collection_id!
         )
       }
-
-      const isDbCollectionPublished =
-        dbCollection &&
-        (await this.collectionService.isDCLPublished(
-          dbCollection.contract_address!
-        ))
 
       if (isDbCollectionPublished) {
         // Prohibits adding new items or moving orphan ones to a published collection

--- a/src/Item/Item.service.ts
+++ b/src/Item/Item.service.ts
@@ -423,22 +423,15 @@ export class ItemService {
     dbCollection: CollectionAttributes | undefined,
     eth_address: string
   ): Promise<FullItem> {
-    let isManager = false
     const isDbCollectionPublished =
       dbCollection &&
       (await this.collectionService.isDCLPublished(
         dbCollection.contract_address!
       ))
 
-    if (isDbCollectionPublished) {
-      const remoteCollection = await collectionAPI.fetchCollection(
-        dbCollection!.contract_address!
-      )
-
-      isManager = remoteCollection!.managers.some(
-        manager => manager === eth_address
-      )
-    }
+    const isManager =
+      isDbCollectionPublished &&
+      (await this.collectionService.isDCLManager(dbCollection!.id, eth_address))
 
     const canUpsert =
       (await new Ownable(Item).canUpsert(item.id, eth_address)) || isManager

--- a/src/Item/Item.service.ts
+++ b/src/Item/Item.service.ts
@@ -432,7 +432,7 @@ export class ItemService {
 
     if (isDbCollectionPublished) {
       const remoteCollection = await collectionAPI.fetchCollection(
-        dbCollection.contract_address!
+        dbCollection!.contract_address!
       )
 
       isManager = remoteCollection!.managers.some(


### PR DESCRIPTION
This PR validates when updating a published item that the sender is the owner or a manager.

Closes #613