### PR TITLE
feat: add possiblity to sort by updated_date and oldest collections

### DIFF
--- a/src/Collection/Collection.model.ts
+++ b/src/Collection/Collection.model.ts
@@ -1,11 +1,11 @@
 import { Model, raw, SQL } from 'decentraland-server'
 import { DEFAULT_LIMIT } from '../Pagination/utils'
-import { CurationStatusFilter, CurationStatusSort } from '../Curation'
+import { CurationStatusFilter } from '../Curation'
 import { CollectionCuration } from '../Curation/CollectionCuration'
 import { ItemCuration } from '../Curation/ItemCuration'
 import { database } from '../database/database'
 import { Item } from '../Item/Item.model'
-import { CollectionAttributes, CollectionTypeFilter } from './Collection.types'
+import { CollectionAttributes, CollectionTypeFilter, CollectionSort } from './Collection.types'
 
 type CollectionWithItemCount = CollectionAttributes & {
   item_count: number
@@ -24,7 +24,7 @@ export type FindCollectionParams = {
   assignee?: string
   status?: CurationStatusFilter
   type?: CollectionTypeFilter
-  sort?: CurationStatusSort
+  sort?: CollectionSort
   isPublished?: boolean
   remoteIds?: CollectionAttributes['id'][]
   itemTags?: string[]
@@ -33,9 +33,9 @@ export type FindCollectionParams = {
 export class Collection extends Model<CollectionAttributes> {
   static tableName = 'collections'
 
-  static getOrderByStatement(sort?: CurationStatusSort, remoteIds?: string[]) {
+  static getOrderByStatement(sort?: CollectionSort, remoteIds?: string[]) {
     switch (sort) {
-      case CurationStatusSort.MOST_RELEVANT:
+      case CollectionSort.MOST_RELEVANT:
         // Order should be
         // 1- To review: Not assigned && isApproved false from the contract
         // 2- Under review: Assigned && isApproved false from the contract OR has pending curation
@@ -55,17 +55,17 @@ export class Collection extends Model<CollectionAttributes> {
             ELSE 4
           END, collections.created_at DESC
         `
-      case CurationStatusSort.NAME_ASC:
+      case CollectionSort.NAME_ASC:
         return SQL`ORDER BY collections.name ASC`
-      case CurationStatusSort.NAME_DESC:
+      case CollectionSort.NAME_DESC:
         return SQL`ORDER BY collections.name DESC`
-      case CurationStatusSort.NEWEST:
+      case CollectionSort.NEWEST:
         return SQL`ORDER BY collections.created_at DESC`
-      case CurationStatusSort.OLDEST:
+      case CollectionSort.OLDEST:
         return SQL`ORDER BY collections.created_at ASC`
-      case CurationStatusSort.UPDATED_AT_ASC:
+      case CollectionSort.UPDATED_AT_ASC:
         return SQL`ORDER BY collections.updated_at ASC`
-      case CurationStatusSort.UPDATED_AT_DESC:
+      case CollectionSort.UPDATED_AT_DESC:
         return SQL`ORDER BY collections.updated_at DESC`
 
       default:

--- a/src/Collection/Collection.model.ts
+++ b/src/Collection/Collection.model.ts
@@ -61,6 +61,13 @@ export class Collection extends Model<CollectionAttributes> {
         return SQL`ORDER BY collections.name DESC`
       case CurationStatusSort.NEWEST:
         return SQL`ORDER BY collections.created_at DESC`
+      case CurationStatusSort.OLDEST:
+        return SQL`ORDER BY collections.created_at ASC`
+      case CurationStatusSort.UPDATED_AT_ASC:
+        return SQL`ORDER BY collections.updated_at ASC`
+      case CurationStatusSort.UPDATED_AT_DESC:
+        return SQL`ORDER BY collections.updated_at DESC`
+
       default:
         return SQL``
     }

--- a/src/Collection/Collection.model.ts
+++ b/src/Collection/Collection.model.ts
@@ -59,9 +59,9 @@ export class Collection extends Model<CollectionAttributes> {
         return SQL`ORDER BY collections.name ASC`
       case CollectionSort.NAME_DESC:
         return SQL`ORDER BY collections.name DESC`
-      case CollectionSort.NEWEST:
+      case CollectionSort.CREATED_AT_DESC:
         return SQL`ORDER BY collections.created_at DESC`
-      case CollectionSort.OLDEST:
+      case CollectionSort.CREATED_AT_ASC:
         return SQL`ORDER BY collections.created_at ASC`
       case CollectionSort.UPDATED_AT_ASC:
         return SQL`ORDER BY collections.updated_at ASC`

--- a/src/Collection/Collection.router.spec.ts
+++ b/src/Collection/Collection.router.spec.ts
@@ -66,7 +66,7 @@ import {
   SlotUsageCheque,
   SlotUsageChequeAttributes,
 } from '../SlotUsageCheque'
-import { CurationStatus, CurationStatusSort } from '../Curation'
+import { CurationStatus } from '../Curation'
 import { isCommitteeMember } from '../Committee'
 import { app } from '../server'
 import { hasPublicAccess } from './access'
@@ -76,6 +76,7 @@ import {
   CollectionAttributes,
   ThirdPartyCollectionAttributes,
   FullCollection,
+  CollectionSort
 } from './Collection.types'
 
 const server = supertest(app.getApp())
@@ -1059,12 +1060,15 @@ describe('Collection router', () => {
       let page: number,
         limit: number,
         isPublished: string,
-        totalCollectionsFromDb: number
+        totalCollectionsFromDb: number,
+        sort: string
+  
       beforeEach(() => {
         ;(page = 1),
           (limit = 3),
           (isPublished = 'true'),
-          (totalCollectionsFromDb = 1)
+          (totalCollectionsFromDb = 1),
+          (sort=CollectionSort.NAME_ASC)
         ;(Collection.findAll as jest.Mock).mockReturnValueOnce([
           { ...dbCollection, collection_count: totalCollectionsFromDb },
         ])
@@ -1078,7 +1082,7 @@ describe('Collection router', () => {
         return server
           .get(
             buildURL(
-              `${url}?limit=${limit}&page=${page}&is_published=${isPublished}`
+              `${url}?limit=${limit}&page=${page}&is_published=${isPublished}&sort=${sort}`
             )
           )
           .set(createAuthHeaders('get', url))
@@ -1104,7 +1108,7 @@ describe('Collection router', () => {
               address: wallet.address,
               limit,
               offset: page - 1,
-              sort: CurationStatusSort.NEWEST,
+              sort,
               isPublished: true,
               thirdPartyIds: [],
               remoteIds: [],
@@ -1141,7 +1145,7 @@ describe('Collection router', () => {
               address: wallet.address,
               limit: undefined,
               offset: undefined,
-              sort: CurationStatusSort.NEWEST,
+              sort: CollectionSort.NEWEST,
               thirdPartyIds: [dbTPCollection.third_party_id],
               remoteIds: [],
             })

--- a/src/Collection/Collection.router.spec.ts
+++ b/src/Collection/Collection.router.spec.ts
@@ -1068,7 +1068,7 @@ describe('Collection router', () => {
           (limit = 3),
           (isPublished = 'true'),
           (totalCollectionsFromDb = 1),
-          (sort=CollectionSort.NAME_ASC)
+          (sort = CollectionSort.NAME_ASC)
         ;(Collection.findAll as jest.Mock).mockReturnValueOnce([
           { ...dbCollection, collection_count: totalCollectionsFromDb },
         ])
@@ -1145,7 +1145,7 @@ describe('Collection router', () => {
               address: wallet.address,
               limit: undefined,
               offset: undefined,
-              sort: CollectionSort.NEWEST,
+              sort: CollectionSort.CREATED_AT_DESC,
               thirdPartyIds: [dbTPCollection.third_party_id],
               remoteIds: [],
             })

--- a/src/Collection/Collection.router.ts
+++ b/src/Collection/Collection.router.ts
@@ -290,7 +290,7 @@ export class CollectionRouter extends Router {
     req: AuthRequest
   ): Promise<PaginatedResponse<FullCollection> | FullCollection[]> => {
     const { page, limit } = getPaginationParams(req)
-    const { is_published } = req.query
+    const { is_published, sort } = req.query
     const eth_address = server.extractFromReq(req, 'address')
     const auth_address = req.auth.ethAddress
 
@@ -311,7 +311,7 @@ export class CollectionRouter extends Router {
         offset: page && limit ? getOffset(page, limit) : undefined,
         limit,
         address: eth_address,
-        sort: CurationStatusSort.NEWEST,
+        sort: sort as CurationStatusSort || CurationStatusSort.NEWEST,
         isPublished: is_published ? is_published === 'true' : undefined,
         remoteIds: authorizedRemoteCollections.map(
           (remoteCollection) => remoteCollection.id

--- a/src/Collection/Collection.router.ts
+++ b/src/Collection/Collection.router.ts
@@ -38,7 +38,7 @@ import {
   getOffset,
   getPaginationParams,
 } from '../Pagination/utils'
-import { CurationStatusFilter, CurationStatusSort } from '../Curation'
+import { CurationStatusFilter } from '../Curation'
 import { hasTPCollectionURN, isTPCollection } from '../utils/urn'
 import { Collection } from './Collection.model'
 import { CollectionService } from './Collection.service'
@@ -46,7 +46,8 @@ import {
   PublishCollectionResponse,
   CollectionAttributes,
   FullCollection,
-  CollectionTypeFilter
+  CollectionTypeFilter,
+  CollectionSort
 } from './Collection.types'
 import { upsertCollectionSchema, saveTOSSchema } from './Collection.schema'
 import { hasPublicAccess } from './access'
@@ -254,7 +255,7 @@ export class CollectionRouter extends Router {
       assignee: assignee as string,
       status: status as CurationStatusFilter,
       type: type as CollectionTypeFilter,
-      sort: sort as CurationStatusSort,
+      sort: sort as CollectionSort,
       isPublished: is_published ? is_published === 'true' : undefined,
       offset: page && limit ? getOffset(page, limit) : undefined,
       limit,
@@ -311,7 +312,7 @@ export class CollectionRouter extends Router {
         offset: page && limit ? getOffset(page, limit) : undefined,
         limit,
         address: eth_address,
-        sort: sort as CurationStatusSort || CurationStatusSort.NEWEST,
+        sort: sort as CollectionSort || CollectionSort.NEWEST,
         isPublished: is_published ? is_published === 'true' : undefined,
         remoteIds: authorizedRemoteCollections.map(
           (remoteCollection) => remoteCollection.id
@@ -615,7 +616,7 @@ export class CollectionRouter extends Router {
       q: q as string,
       assignee: assignee as string,
       status: status as CurationStatusFilter,
-      sort: sort as CurationStatusSort,
+      sort: sort as CollectionSort,
       isPublished: is_published ? is_published === 'true' : undefined,
       offset: page && limit ? getOffset(page, limit) : undefined,
       limit,

--- a/src/Collection/Collection.router.ts
+++ b/src/Collection/Collection.router.ts
@@ -312,7 +312,7 @@ export class CollectionRouter extends Router {
         offset: page && limit ? getOffset(page, limit) : undefined,
         limit,
         address: eth_address,
-        sort: sort as CollectionSort || CollectionSort.NEWEST,
+        sort: sort as CollectionSort || CollectionSort.CREATED_AT_DESC,
         isPublished: is_published ? is_published === 'true' : undefined,
         remoteIds: authorizedRemoteCollections.map(
           (remoteCollection) => remoteCollection.id

--- a/src/Collection/Collection.types.ts
+++ b/src/Collection/Collection.types.ts
@@ -51,8 +51,8 @@ export enum CollectionTypeFilter {
 
 export enum CollectionSort {
   MOST_RELEVANT = 'MOST_RELEVANT',
-  NEWEST = 'NEWEST',
-  OLDEST = 'OLDEST',
+  CREATED_AT_DESC = 'CREATED_AT_DESC',
+  CREATED_AT_ASC = 'CREATED_AT_ASC',
   NAME_DESC = 'NAME_DESC',
   NAME_ASC = 'NAME_ASC',
   UPDATED_AT_DESC = 'UPDATED_AT_DESC',

--- a/src/Collection/Collection.types.ts
+++ b/src/Collection/Collection.types.ts
@@ -48,3 +48,13 @@ export enum CollectionTypeFilter {
   STANDARD = 'standard',
   THIRD_PARTY = 'third_party'
 }
+
+export enum CollectionSort {
+  MOST_RELEVANT = 'MOST_RELEVANT',
+  NEWEST = 'NEWEST',
+  OLDEST = 'OLDEST',
+  NAME_DESC = 'NAME_DESC',
+  NAME_ASC = 'NAME_ASC',
+  UPDATED_AT_DESC = 'UPDATED_AT_DESC',
+  UPDATED_AT_ASC = 'UPDATED_AT_ASC'
+}

--- a/src/Curation/Curation.types.ts
+++ b/src/Curation/Curation.types.ts
@@ -20,8 +20,11 @@ export enum CurationStatusFilter {
 export enum CurationStatusSort {
   MOST_RELEVANT = 'MOST_RELEVANT',
   NEWEST = 'NEWEST',
+  OLDEST = 'OLDEST',
   NAME_DESC = 'NAME_DESC',
   NAME_ASC = 'NAME_ASC',
+  UPDATED_AT_DESC = 'UPDATED_AT_DESC',
+  UPDATED_AT_ASC = 'UPDATED_AT_ASC'
 }
 
 export const patchCurationSchema = Object.freeze({

--- a/src/Curation/Curation.types.ts
+++ b/src/Curation/Curation.types.ts
@@ -17,16 +17,6 @@ export enum CurationStatusFilter {
   UNDER_REVIEW = 'under_review',
 }
 
-export enum CurationStatusSort {
-  MOST_RELEVANT = 'MOST_RELEVANT',
-  NEWEST = 'NEWEST',
-  OLDEST = 'OLDEST',
-  NAME_DESC = 'NAME_DESC',
-  NAME_ASC = 'NAME_ASC',
-  UPDATED_AT_DESC = 'UPDATED_AT_DESC',
-  UPDATED_AT_ASC = 'UPDATED_AT_ASC'
-}
-
 export const patchCurationSchema = Object.freeze({
   type: 'object',
   properties: {


### PR DESCRIPTION
Add new sorting possiblities to the collections list. Items added: `updated_at_asc`, `updated_at_desc` and `oldest` (this las one is to remain consistent with the `newest` option)