### PR TITLE
feat: Update logic to move allowed items between collections

### DIFF
--- a/src/Item/Item.router.spec.ts
+++ b/src/Item/Item.router.spec.ts
@@ -1535,6 +1535,7 @@ describe('Item router', () => {
       describe('and the collection of the item is being changed', () => {
         beforeEach(() => {
           mockItem.findOne.mockResolvedValueOnce(itemToUpsert)
+          mockItem.hasPublishedItems.mockResolvedValueOnce(true)
           mockCollection.findByIds.mockResolvedValueOnce([
             {
               ...collectionMock,
@@ -1545,17 +1546,19 @@ describe('Item router', () => {
           mockOwnableCanUpsert(Item, itemToUpsert.id, wallet.address, true)
         })
 
-        it('should fail with cant change item collection message', async () => {
-          const response = await server
-            .put(buildURL(url))
-            .send({ item: { ...itemToUpsert, collection_id: mockUUID } })
-            .set(createAuthHeaders('put', url))
-            .expect(STATUS_CODES.unauthorized)
+        describe('and the collection to move the item is published', () => {
+          it('should fail with cant change item collection message', async () => {
+            const response = await server
+              .put(buildURL(url))
+              .send({ item: { ...itemToUpsert, collection_id: mockUUID } })
+              .set(createAuthHeaders('put', url))
+              .expect(STATUS_CODES.unauthorized)
 
-          expect(response.body).toEqual({
-            data: { id: dbItem.id },
-            error: "Item can't change between collections.",
-            ok: false,
+            expect(response.body).toEqual({
+              data: { id: dbItem.id },
+              error: "Item can't change between collections.",
+              ok: false,
+            })
           })
         })
       })

--- a/src/Item/Item.service.ts
+++ b/src/Item/Item.service.ts
@@ -47,10 +47,10 @@ export class ItemService {
   private collectionService = new CollectionService()
 
   /**
-   * Updates or insert an item, either a third party item or a decentraland item.
+   * Updates or insert an item, either a third party item or a standard item.
    *
    * @param item - The item to be updated or inserted.
-   * @param eth_address - The item in the DB to be updated or inserted.
+   * @param eth_address - The address that is trying to upsert the item.
    */
   public async upsertItem(
     item: FullItem,
@@ -75,8 +75,8 @@ export class ItemService {
       // Moving items between published collections is forbidden
       if (
         this.checkItemIsMovedToAnotherCollection(item, dbItem) &&
-        (!(await this.checkItemCollectionIsValidToMove(item.collection_id)) ||
-          !(await this.checkItemCollectionIsValidToMove(dbItem.collection_id)))
+        (!(await this.checkCanAddItemsToCollection(item.collection_id)) ||
+          !(await this.checkCanAddItemsToCollection(dbItem.collection_id)))
       ) {
         throw new ItemCantBeMovedFromCollectionError(item.id)
       }
@@ -346,7 +346,7 @@ export class ItemService {
     return { item, collection }
   }
 
-  private async checkItemCollectionIsValidToMove(
+  private async checkCanAddItemsToCollection(
     collectionId: string | null
   ): Promise<boolean> {
     if (collectionId) {

--- a/src/Item/Item.service.ts
+++ b/src/Item/Item.service.ts
@@ -72,8 +72,14 @@ export class ItemService {
     }
 
     if (dbItem) {
-      // Moving items between collections is forbidden
-      this.checkItemIsMovedToAnotherCollection(item, dbItem)
+      // Moving items between published collections is forbidden
+      if (
+        this.checkItemIsMovedToAnotherCollection(item, dbItem) &&
+        (!(await this.checkItemCollectionIsValidToMove(item.collection_id)) ||
+          !(await this.checkItemCollectionIsValidToMove(dbItem.collection_id)))
+      ) {
+        throw new ItemCantBeMovedFromCollectionError(item.id)
+      }
     }
 
     const collectionId: string | null =
@@ -340,20 +346,40 @@ export class ItemService {
     return { item, collection }
   }
 
+  private async checkItemCollectionIsValidToMove(
+    collectionId: string | null
+  ): Promise<boolean> {
+    if (collectionId) {
+      const collection = await this.collectionService.getDBCollection(
+        collectionId
+      )
+
+      if (isTPCollection(collection)) {
+        return false
+      }
+
+      const isCollectionPublished =
+        collection.contract_address &&
+        (await this.collectionService.isDCLPublished(
+          collection.contract_address
+        ))
+      return isCollectionPublished === false
+    }
+
+    return false
+  }
+
   private checkItemIsMovedToAnotherCollection(
     itemToUpsert: FullItem,
     dbItem: ItemAttributes
-  ): void {
+  ): boolean {
     const areBothCollectionIdsDefined =
-      itemToUpsert.collection_id && dbItem.collection_id
+      !!itemToUpsert.collection_id && !!dbItem.collection_id
 
-    const isItemCollectionBeingChanged =
+    return (
       areBothCollectionIdsDefined &&
       itemToUpsert.collection_id !== dbItem.collection_id
-
-    if (isItemCollectionBeingChanged) {
-      throw new ItemCantBeMovedFromCollectionError(itemToUpsert.id)
-    }
+    )
   }
 
   private async deleteDCLItem(dbItem: ItemAttributes): Promise<void> {


### PR DESCRIPTION
This PR allows moving items between unpublished collections.

Closes #2347