### PR TITLE
fix: open sea doesn't return an owner for ENSs

### DIFF
--- a/src/NFT/NFT.service.spec.ts
+++ b/src/NFT/NFT.service.spec.ts
@@ -264,13 +264,48 @@ describe('when getting a list of nfts', () => {
     })
   })
 
-  it('should return cursor data and the list of nfts', async () => {
-    const data = await service.getNFTs()
+  describe('when the response is ok', () => {
+    it('should return cursor data and the list of nfts', async () => {
+      const data = await service.getNFTs()
 
-    expect(data).toEqual({
-      next: 'next',
-      nfts: [mockMappedExternalNFT],
-      previous: 'previous',
+      expect(data).toEqual({
+        next: 'next',
+        nfts: [mockMappedExternalNFT],
+        previous: 'previous',
+      })
+    })
+
+    describe('and is an ens', () => {
+      let mockNFT: any
+      let mockMappedNFT: NFT
+      beforeEach(() => {
+        mockNFT = { ...mockExternalNFT, owner: null, top_ownerships: undefined }
+        mockMappedNFT = {
+          ...mockMappedExternalNFT,
+          owner: null,
+          topOwnerships: null,
+        }
+        mockFetch.mockReset()
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              next: 'next',
+              previous: 'previous',
+              assets: [mockNFT],
+            }),
+        } as Response)
+      })
+
+      it('should return an nft without owner', async () => {
+        const data = await service.getNFTs()
+
+        expect(data).toEqual({
+          next: 'next',
+          nfts: [mockMappedNFT],
+          previous: 'previous',
+        })
+      })
     })
   })
 })

--- a/src/NFT/NFT.service.ts
+++ b/src/NFT/NFT.service.ts
@@ -208,7 +208,7 @@ export class NFTService {
       name: ext.name,
       description: ext.description,
       externalLink: ext.external_link,
-      owner: mapAccount(ext.owner),
+      owner: ext.owner ? mapAccount(ext.owner) : null,
       contract: mapContract(ext.asset_contract),
       traits: (ext.traits as any[]).map(mapTrait),
       lastSale: ext.last_sale ? mapSale(ext.last_sale) : null,

--- a/src/NFT/NFT.types.ts
+++ b/src/NFT/NFT.types.ts
@@ -9,7 +9,7 @@ export type NFT = {
   name: string | null
   description: string | null
   externalLink: string | null
-  owner: NFTAccount
+  owner: NFTAccount | null
   contract: NFTContract
   traits: NFTTrait[]
   lastSale: NFTSale | null


### PR DESCRIPTION
This PR validates opensea response contains an owner before mapping the account property