### PR TITLE
fix: filter third party collections in contract addresses endpoint

### DIFF
--- a/src/Collection/Collection.router.spec.ts
+++ b/src/Collection/Collection.router.spec.ts
@@ -76,7 +76,8 @@ import {
   CollectionAttributes,
   ThirdPartyCollectionAttributes,
   FullCollection,
-  CollectionSort
+  CollectionSort,
+  CollectionTypeFilter
 } from './Collection.types'
 
 const server = supertest(app.getApp())
@@ -2656,6 +2657,7 @@ describe('Collection router', () => {
               status: undefined,
               limit,
               offset: page - 1, // it's the offset,
+              type: CollectionTypeFilter.STANDARD,
               thirdPartyIds: [],
               remoteIds: [],
               itemTags: undefined,
@@ -2716,6 +2718,7 @@ describe('Collection router', () => {
               limit,
               thirdPartyIds: [],
               remoteIds: [],
+              type: CollectionTypeFilter.STANDARD,
               itemTags: [itemTag.toLowerCase()],
             })
           })
@@ -2776,6 +2779,7 @@ describe('Collection router', () => {
               limit,
               thirdPartyIds: [],
               remoteIds: [],
+              type: CollectionTypeFilter.STANDARD,
               itemTags: [itemTag.toLowerCase(), itemTag2.toLowerCase()],
             })
           })

--- a/src/Collection/Collection.router.ts
+++ b/src/Collection/Collection.router.ts
@@ -620,6 +620,7 @@ export class CollectionRouter extends Router {
       isPublished: is_published ? is_published === 'true' : undefined,
       offset: page && limit ? getOffset(page, limit) : undefined,
       limit,
+      type: CollectionTypeFilter.STANDARD,
       remoteIds: status
         ? remoteCollections.map((c) => c.id)
         : // if the status is not passed, we still want to prioritize the not approved. It won't filter by them, it'll just use them for the sort.


### PR DESCRIPTION
When asking for collections contract addresses the endpoint is returning some nulls in the array this is due to the fact that it is also retrieving third party collections that will never have a contract address associated to it. This prs adds the filter to only consider standard collections for this endpoint

Closes #635 