### PR TITLE
feat: Add custom max-age and s-maxage headers to /addresses endpoint

### DIFF
--- a/src/Collection/Collection.router.ts
+++ b/src/Collection/Collection.router.ts
@@ -1,4 +1,4 @@
-import { Request } from 'express'
+import { Request, Response } from 'express'
 import { server } from 'decentraland-server'
 import { omit } from 'decentraland-commons/dist/utils'
 import { Router } from '../common/Router'
@@ -39,6 +39,7 @@ import {
   getPaginationParams,
 } from '../Pagination/utils'
 import { CurationStatusFilter } from '../Curation'
+import { addCustomMaxAgeCacheControlHeader } from '../common/headers'
 import { hasTPCollectionURN, isTPCollection } from '../utils/urn'
 import { Collection } from './Collection.model'
 import { CollectionService } from './Collection.service'
@@ -601,7 +602,8 @@ export class CollectionRouter extends Router {
   }
 
   getAddressesCollections = async (
-    req: Request
+    req: Request,
+    res: Response
   ): Promise<PaginatedResponse<string> | string[]> => {
     const { page, limit } = getPaginationParams(req)
     const { assignee, status, sort, q, is_published, tag } = req.query
@@ -643,6 +645,9 @@ export class CollectionRouter extends Router {
     const consolidated = (
       await Bridge.consolidateAllCollections(dbCollections, remoteCollections)
     ).map((collection) => collection.contract_address!)
+
+    const RES_MAX_AGE = 300 // 5 mins
+    addCustomMaxAgeCacheControlHeader(res, RES_MAX_AGE)
 
     return page && limit
       ? generatePaginatedResponse(consolidated, totalCollections, limit, page)

--- a/src/common/headers.ts
+++ b/src/common/headers.ts
@@ -5,3 +5,11 @@ const DEFAULT_CACHE_CONTROL = 'public,max-age=31536000,immutable'
 export function addInmutableCacheControlHeader(res: Response): void {
   res.setHeader('Cache-Control', DEFAULT_CACHE_CONTROL)
 }
+
+/* Adds a custom public,max-age,s-maxage header to the Response object */
+export function addCustomMaxAgeCacheControlHeader(
+  res: Response,
+  maxAge: number
+): void {
+  res.setHeader('Cache-Control', `public,max-age=${maxAge},s-maxage=${maxAge}`)
+}


### PR DESCRIPTION
Adds a cache headers to the /addresses endpoint so it gets cached for 5 minutes