### PR TITLE
feat: Add support for fuzzy search for /collections endpoint

### DIFF
--- a/migrations/1695119925617_add-trgm-extension.ts
+++ b/migrations/1695119925617_add-trgm-extension.ts
@@ -1,0 +1,13 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate'
+
+export const shorthands: ColumnDefinitions | undefined = undefined
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addExtension('pg_trgm', { ifNotExists: true })
+  pgm.sql('SET pg_trgm.similarity_threshold = 0.5')
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropExtension('pg_trgm')
+}

--- a/src/Collection/Collection.model.ts
+++ b/src/Collection/Collection.model.ts
@@ -110,7 +110,7 @@ export class Collection extends Model<CollectionAttributes> {
     const isInRemoteIds = SQL`collections.contract_address = ANY(${remoteIds})`
     const sameStatusAndInTheBlockchain = SQL`(collection_curations.status = ${status} AND (${isInRemoteIds} OR (${isThirdParty})))`
     const conditions = [
-      q ? SQL`collections.name ILIKE '%' || ${q} || '%'` : undefined,
+      q ? SQL`collections.name % ${q} ` : undefined,
       assignee ? SQL`collection_curations.assignee = ${assignee}` : undefined,
       address
         ? thirdPartyIds?.length

--- a/src/Collection/Collection.router.spec.ts
+++ b/src/Collection/Collection.router.spec.ts
@@ -849,7 +849,7 @@ describe('Collection router', () => {
       })
     })
 
-    describe('and its not a committee member but has request has the params "q" for a search term and "isPublished"', () => {
+    describe('and its not a committee member but the request has the params "q" for a search term and "isPublished"', () => {
       let q: string
       let isPublished: boolean
       beforeEach(() => {

--- a/src/Collection/Collection.router.spec.ts
+++ b/src/Collection/Collection.router.spec.ts
@@ -828,222 +828,467 @@ describe('Collection router', () => {
   })
 
   describe('when retrieving all the collections', () => {
-    beforeEach(() => {
-      ;(isCommitteeMember as jest.Mock).mockResolvedValueOnce(true)
-      ;(Collection.findByContractAddresses as jest.Mock).mockResolvedValueOnce(
-        []
-      )
-      ;(collectionAPI.fetchCollections as jest.Mock).mockResolvedValueOnce([])
-      thirdPartyAPIMock.fetchThirdParties.mockResolvedValueOnce([])
-    })
-
-    describe('and sending pagination params', () => {
-      let page: number, limit: number
+    describe('and its not a committee member and is not sending the query params "q" and "isPublished', () => {
       let baseUrl: string
-      let totalCollectionsFromDb: number
       beforeEach(() => {
-        ;(page = 1), (limit = 3)
-        totalCollectionsFromDb = 1
-        baseUrl = '/collections'
-        url = `${baseUrl}?limit=${limit}&page=${page}`
-        ;(Collection.findAll as jest.Mock).mockResolvedValueOnce([
-          { ...dbCollection, collection_count: totalCollectionsFromDb },
-        ])
+        ;(isCommitteeMember as jest.Mock).mockResolvedValueOnce(false)
+        url = '/collections'
       })
-      it('should respond with pagination data and should have call the findAll method with the params', () => {
+      it('should return a 401 and a message saying that the user is not authorized', () => {
         return server
           .get(buildURL(url))
           .set(createAuthHeaders('get', baseUrl))
-          .expect(200)
+          .expect(401)
           .then((response: any) => {
             expect(response.body).toEqual({
-              data: {
-                total: totalCollectionsFromDb,
-                pages: totalCollectionsFromDb,
-                page,
-                limit,
-                results: [
-                  {
-                    ...resultingCollectionAttributes,
-                    urn: `urn:decentraland:mumbai:collections-v2:${dbCollection.contract_address}`,
-                  },
-                ],
-              },
-
-              ok: true,
-            })
-            expect(Collection.findAll).toHaveBeenCalledWith({
-              assignee: undefined,
-              isPublished: undefined,
-              q: undefined,
-              sort: undefined,
-              status: undefined,
-              type: undefined,
-              limit,
-              offset: page - 1, // it's the offset,
-              thirdPartyIds: [],
-              remoteIds: [],
+              error: 'Unauthorized',
+              data: { eth_address: '' },
+              ok: false,
             })
           })
       })
     })
 
-    describe('and sending pagination params plus filtering options', () => {
-      let page: number,
-        limit: number,
-        baseUrl: string,
-        totalCollectionsFromDb: number,
-        q: string,
-        assignee: string,
-        status: string,
-        type: string,
-        sort: string,
-        isPublished: string
+    describe('and its not a committee member but has request has the params "q" for a search term and "isPublished"', () => {
+      let q: string
+      let isPublished: boolean
       beforeEach(() => {
-        ;(page = 1), (limit = 3)
-        assignee = '0x1234567890123456789012345678901234567890'
-        status = 'published'
-        type = 'standard'
-        sort = 'NAME_DESC'
-        isPublished = 'true'
-        q = 'collection name 1'
-        totalCollectionsFromDb = 1
-        baseUrl = '/collections'
-        url = `${baseUrl}?limit=${limit}&page=${page}&assignee=${assignee}&status=${status}&type=${type}&sort=${sort}&is_published=${isPublished}&q=${q}`
-        ;(Collection.findAll as jest.Mock).mockResolvedValueOnce([
-          { ...dbCollection, collection_count: totalCollectionsFromDb },
-        ])
+        ;(isCommitteeMember as jest.Mock).mockResolvedValueOnce(false)
+        ;(Collection.findByContractAddresses as jest.Mock).mockResolvedValueOnce(
+          []
+        )
+        // url = '/collections?q=name&isPublished=true'
+        ;(collectionAPI.fetchCollections as jest.Mock).mockResolvedValueOnce([])
+        thirdPartyAPIMock.fetchThirdParties.mockResolvedValueOnce([])
       })
-      it('should respond with pagination data and should have call the findAll method with the right params', () => {
-        return server
-          .get(buildURL(url))
-          .set(createAuthHeaders('get', baseUrl))
-          .expect(200)
-          .then((response: any) => {
-            expect(response.body).toEqual({
-              data: {
-                total: totalCollectionsFromDb,
-                pages: totalCollectionsFromDb,
-                page,
-                limit,
-                results: [
-                  {
-                    ...resultingCollectionAttributes,
-                    urn: `urn:decentraland:mumbai:collections-v2:${dbCollection.contract_address}`,
-                  },
-                ],
-              },
-
-              ok: true,
-            })
-            expect(Collection.findAll).toHaveBeenCalledWith({
-              q,
-              assignee,
-              status,
-              type,
-              sort,
-              isPublished: true,
-              offset: page - 1, // it's the offset
-              limit,
-              thirdPartyIds: [],
-              remoteIds: [],
-              itemTags: undefined,
-            })
-          })
-      })
-    })
-
-    describe('and sending pagination params plus filtering with array tag options', () => {
-      let page: number,
-        limit: number,
-        baseUrl: string,
-        totalCollectionsFromDb: number,
-        q: string,
-        assignee: string,
-        status: string,
-        type: string,
-        sort: string,
-        isPublished: string,
-        itemTag: string,
-        itemTag2: string
-      beforeEach(() => {
-        ;(page = 1), (limit = 3)
-        assignee = '0x1234567890123456789012345678901234567890'
-        status = 'published'
-        type = 'standard'
-        sort = 'NAME_DESC'
-        isPublished = 'true'
-        q = 'collection name 1'
-        itemTag = 'TAG'
-        itemTag2 = 'TAG2'
-        totalCollectionsFromDb = 1
-        baseUrl = '/collections'
-        url = `${baseUrl}?limit=${limit}&page=${page}&assignee=${assignee}&status=${status}&type=${type}&sort=${sort}&is_published=${isPublished}&q=${q}&tag=${itemTag}&tag=${itemTag2}`
-        ;(Collection.findAll as jest.Mock).mockResolvedValueOnce([
-          { ...dbCollection, collection_count: totalCollectionsFromDb },
-        ])
-      })
-      it('should respond with pagination data and should have call the findAll method with the right params', () => {
-        return server
-          .get(buildURL(url))
-          .set(createAuthHeaders('get', baseUrl))
-          .expect(200)
-          .then((response: any) => {
-            expect(response.body).toEqual({
-              data: {
-                total: totalCollectionsFromDb,
-                pages: totalCollectionsFromDb,
-                page,
-                limit,
-                results: [
-                  {
-                    ...resultingCollectionAttributes,
-                    urn: `urn:decentraland:mumbai:collections-v2:${dbCollection.contract_address}`,
-                  },
-                ],
-              },
-              ok: true,
-            })
-            expect(Collection.findAll).toHaveBeenCalledWith({
-              q,
-              assignee,
-              status,
-              type,
-              sort,
-              isPublished: true,
-              offset: page - 1, // it's the offset
-              limit,
-              thirdPartyIds: [],
-              remoteIds: [],
-              itemTags: [itemTag.toLowerCase(), itemTag2.toLowerCase()],
-            })
-          })
-      })
-    })
-
-    describe('and not sending any pagination params ', () => {
-      beforeEach(() => {
-        url = `/collections`
-        ;(Collection.findAll as jest.Mock)
-          .mockResolvedValueOnce([dbCollection])
-          .mockResolvedValueOnce([])
-      })
-      it('should respond with all the collections with the URN and the legacy response', () => {
-        return server
-          .get(buildURL(url))
-          .set(createAuthHeaders('get', url))
-          .expect(200)
-          .then((response: any) => {
-            expect(response.body).toEqual({
-              data: [
-                {
-                  ...resultingCollectionAttributes,
-                  urn: `urn:decentraland:mumbai:collections-v2:${dbCollection.contract_address}`,
+      describe('and sending pagination params', () => {
+        let page: number, limit: number
+        let baseUrl: string
+        let totalCollectionsFromDb: number
+        beforeEach(() => {
+          ;(page = 1), (limit = 3), (q = 'searchTerm'), (isPublished = true)
+          totalCollectionsFromDb = 1
+          baseUrl = '/collections'
+          url = `${baseUrl}?limit=${limit}&page=${page}&q=${q}&is_published=${isPublished}`
+          ;(Collection.findAll as jest.Mock).mockResolvedValueOnce([
+            { ...dbCollection, collection_count: totalCollectionsFromDb },
+          ])
+        })
+        it('should respond with pagination data and should have call the findAll method with the params', () => {
+          return server
+            .get(buildURL(url))
+            .set(createAuthHeaders('get', baseUrl))
+            .expect(200)
+            .then((response: any) => {
+              expect(response.body).toEqual({
+                data: {
+                  total: totalCollectionsFromDb,
+                  pages: totalCollectionsFromDb,
+                  page,
+                  limit,
+                  results: [
+                    {
+                      ...resultingCollectionAttributes,
+                      urn: `urn:decentraland:mumbai:collections-v2:${dbCollection.contract_address}`,
+                    },
+                  ],
                 },
-              ],
-              ok: true,
+
+                ok: true,
+              })
+              expect(Collection.findAll).toHaveBeenCalledWith({
+                assignee: undefined,
+                isPublished,
+                q,
+                sort: undefined,
+                status: undefined,
+                type: undefined,
+                limit,
+                offset: page - 1, // it's the offset,
+                thirdPartyIds: [],
+                remoteIds: [],
+              })
             })
-          })
+        })
+      })
+
+      describe('and sending pagination params plus filtering options', () => {
+        let page: number,
+          limit: number,
+          baseUrl: string,
+          totalCollectionsFromDb: number,
+          q: string,
+          assignee: string,
+          status: string,
+          type: string,
+          sort: string,
+          isPublished: string
+        beforeEach(() => {
+          ;(page = 1), (limit = 3)
+          assignee = '0x1234567890123456789012345678901234567890'
+          status = 'published'
+          type = 'standard'
+          sort = 'NAME_DESC'
+          isPublished = 'true'
+          q = 'collection name 1'
+          totalCollectionsFromDb = 1
+          baseUrl = '/collections'
+          url = `${baseUrl}?limit=${limit}&page=${page}&assignee=${assignee}&status=${status}&type=${type}&sort=${sort}&is_published=${isPublished}&q=${q}`
+          ;(Collection.findAll as jest.Mock).mockResolvedValueOnce([
+            { ...dbCollection, collection_count: totalCollectionsFromDb },
+          ])
+        })
+        it('should respond with pagination data and should have call the findAll method with the right params', () => {
+          return server
+            .get(buildURL(url))
+            .set(createAuthHeaders('get', baseUrl))
+            .expect(200)
+            .then((response: any) => {
+              expect(response.body).toEqual({
+                data: {
+                  total: totalCollectionsFromDb,
+                  pages: totalCollectionsFromDb,
+                  page,
+                  limit,
+                  results: [
+                    {
+                      ...resultingCollectionAttributes,
+                      urn: `urn:decentraland:mumbai:collections-v2:${dbCollection.contract_address}`,
+                    },
+                  ],
+                },
+
+                ok: true,
+              })
+              expect(Collection.findAll).toHaveBeenCalledWith({
+                q,
+                assignee,
+                status,
+                type,
+                sort,
+                isPublished: true,
+                offset: page - 1, // it's the offset
+                limit,
+                thirdPartyIds: [],
+                remoteIds: [],
+                itemTags: undefined,
+              })
+            })
+        })
+      })
+
+      describe('and sending pagination params plus filtering with array tag options', () => {
+        let page: number,
+          limit: number,
+          baseUrl: string,
+          totalCollectionsFromDb: number,
+          q: string,
+          assignee: string,
+          status: string,
+          type: string,
+          sort: string,
+          isPublished: string,
+          itemTag: string,
+          itemTag2: string
+        beforeEach(() => {
+          ;(page = 1), (limit = 3)
+          assignee = '0x1234567890123456789012345678901234567890'
+          status = 'published'
+          type = 'standard'
+          sort = 'NAME_DESC'
+          isPublished = 'true'
+          q = 'collection name 1'
+          itemTag = 'TAG'
+          itemTag2 = 'TAG2'
+          totalCollectionsFromDb = 1
+          baseUrl = '/collections'
+          url = `${baseUrl}?limit=${limit}&page=${page}&assignee=${assignee}&status=${status}&type=${type}&sort=${sort}&is_published=${isPublished}&q=${q}&tag=${itemTag}&tag=${itemTag2}`
+          ;(Collection.findAll as jest.Mock).mockResolvedValueOnce([
+            { ...dbCollection, collection_count: totalCollectionsFromDb },
+          ])
+        })
+        it('should respond with pagination data and should have call the findAll method with the right params', () => {
+          return server
+            .get(buildURL(url))
+            .set(createAuthHeaders('get', baseUrl))
+            .expect(200)
+            .then((response: any) => {
+              expect(response.body).toEqual({
+                data: {
+                  total: totalCollectionsFromDb,
+                  pages: totalCollectionsFromDb,
+                  page,
+                  limit,
+                  results: [
+                    {
+                      ...resultingCollectionAttributes,
+                      urn: `urn:decentraland:mumbai:collections-v2:${dbCollection.contract_address}`,
+                    },
+                  ],
+                },
+                ok: true,
+              })
+              expect(Collection.findAll).toHaveBeenCalledWith({
+                q,
+                assignee,
+                status,
+                type,
+                sort,
+                isPublished: true,
+                offset: page - 1, // it's the offset
+                limit,
+                thirdPartyIds: [],
+                remoteIds: [],
+                itemTags: [itemTag.toLowerCase(), itemTag2.toLowerCase()],
+              })
+            })
+        })
+      })
+
+      describe('and not sending any pagination params ', () => {
+        beforeEach(() => {
+          url = `/collections?q=${q}&is_published=${isPublished}`
+          ;(Collection.findAll as jest.Mock)
+            .mockResolvedValueOnce([dbCollection])
+            .mockResolvedValueOnce([])
+        })
+        it('should respond with all the collections with the URN and the legacy response', () => {
+          return server
+            .get(buildURL(url))
+            .set(createAuthHeaders('get', url))
+            .expect(200)
+            .then((response: any) => {
+              expect(response.body).toEqual({
+                data: [
+                  {
+                    ...resultingCollectionAttributes,
+                    urn: `urn:decentraland:mumbai:collections-v2:${dbCollection.contract_address}`,
+                  },
+                ],
+                ok: true,
+              })
+            })
+        })
+      })
+    })
+
+    describe('and its a request from a committee member', () => {
+      beforeEach(() => {
+        ;(isCommitteeMember as jest.Mock).mockResolvedValueOnce(true)
+        ;(Collection.findByContractAddresses as jest.Mock).mockResolvedValueOnce(
+          []
+        )
+        ;(collectionAPI.fetchCollections as jest.Mock).mockResolvedValueOnce([])
+        thirdPartyAPIMock.fetchThirdParties.mockResolvedValueOnce([])
+      })
+      describe('and sending pagination params', () => {
+        let page: number, limit: number
+        let baseUrl: string
+        let totalCollectionsFromDb: number
+        beforeEach(() => {
+          ;(page = 1), (limit = 3)
+          totalCollectionsFromDb = 1
+          baseUrl = '/collections'
+          url = `${baseUrl}?limit=${limit}&page=${page}`
+          ;(Collection.findAll as jest.Mock).mockResolvedValueOnce([
+            { ...dbCollection, collection_count: totalCollectionsFromDb },
+          ])
+        })
+        it('should respond with pagination data and should have call the findAll method with the params', () => {
+          return server
+            .get(buildURL(url))
+            .set(createAuthHeaders('get', baseUrl))
+            .expect(200)
+            .then((response: any) => {
+              expect(response.body).toEqual({
+                data: {
+                  total: totalCollectionsFromDb,
+                  pages: totalCollectionsFromDb,
+                  page,
+                  limit,
+                  results: [
+                    {
+                      ...resultingCollectionAttributes,
+                      urn: `urn:decentraland:mumbai:collections-v2:${dbCollection.contract_address}`,
+                    },
+                  ],
+                },
+
+                ok: true,
+              })
+              expect(Collection.findAll).toHaveBeenCalledWith({
+                assignee: undefined,
+                isPublished: undefined,
+                q: undefined,
+                sort: undefined,
+                status: undefined,
+                type: undefined,
+                limit,
+                offset: page - 1, // it's the offset,
+                thirdPartyIds: [],
+                remoteIds: [],
+              })
+            })
+        })
+      })
+
+      describe('and sending pagination params plus filtering options', () => {
+        let page: number,
+          limit: number,
+          baseUrl: string,
+          totalCollectionsFromDb: number,
+          q: string,
+          assignee: string,
+          status: string,
+          type: string,
+          sort: string,
+          isPublished: string
+        beforeEach(() => {
+          ;(page = 1), (limit = 3)
+          assignee = '0x1234567890123456789012345678901234567890'
+          status = 'published'
+          type = 'standard'
+          sort = 'NAME_DESC'
+          isPublished = 'true'
+          q = 'collection name 1'
+          totalCollectionsFromDb = 1
+          baseUrl = '/collections'
+          url = `${baseUrl}?limit=${limit}&page=${page}&assignee=${assignee}&status=${status}&type=${type}&sort=${sort}&is_published=${isPublished}&q=${q}`
+          ;(Collection.findAll as jest.Mock).mockResolvedValueOnce([
+            { ...dbCollection, collection_count: totalCollectionsFromDb },
+          ])
+        })
+        it('should respond with pagination data and should have call the findAll method with the right params', () => {
+          return server
+            .get(buildURL(url))
+            .set(createAuthHeaders('get', baseUrl))
+            .expect(200)
+            .then((response: any) => {
+              expect(response.body).toEqual({
+                data: {
+                  total: totalCollectionsFromDb,
+                  pages: totalCollectionsFromDb,
+                  page,
+                  limit,
+                  results: [
+                    {
+                      ...resultingCollectionAttributes,
+                      urn: `urn:decentraland:mumbai:collections-v2:${dbCollection.contract_address}`,
+                    },
+                  ],
+                },
+
+                ok: true,
+              })
+              expect(Collection.findAll).toHaveBeenCalledWith({
+                q,
+                assignee,
+                status,
+                type,
+                sort,
+                isPublished: true,
+                offset: page - 1, // it's the offset
+                limit,
+                thirdPartyIds: [],
+                remoteIds: [],
+                itemTags: undefined,
+              })
+            })
+        })
+      })
+
+      describe('and sending pagination params plus filtering with array tag options', () => {
+        let page: number,
+          limit: number,
+          baseUrl: string,
+          totalCollectionsFromDb: number,
+          q: string,
+          assignee: string,
+          status: string,
+          type: string,
+          sort: string,
+          isPublished: string,
+          itemTag: string,
+          itemTag2: string
+        beforeEach(() => {
+          ;(page = 1), (limit = 3)
+          assignee = '0x1234567890123456789012345678901234567890'
+          status = 'published'
+          type = 'standard'
+          sort = 'NAME_DESC'
+          isPublished = 'true'
+          q = 'collection name 1'
+          itemTag = 'TAG'
+          itemTag2 = 'TAG2'
+          totalCollectionsFromDb = 1
+          baseUrl = '/collections'
+          url = `${baseUrl}?limit=${limit}&page=${page}&assignee=${assignee}&status=${status}&type=${type}&sort=${sort}&is_published=${isPublished}&q=${q}&tag=${itemTag}&tag=${itemTag2}`
+          ;(Collection.findAll as jest.Mock).mockResolvedValueOnce([
+            { ...dbCollection, collection_count: totalCollectionsFromDb },
+          ])
+        })
+        it('should respond with pagination data and should have call the findAll method with the right params', () => {
+          return server
+            .get(buildURL(url))
+            .set(createAuthHeaders('get', baseUrl))
+            .expect(200)
+            .then((response: any) => {
+              expect(response.body).toEqual({
+                data: {
+                  total: totalCollectionsFromDb,
+                  pages: totalCollectionsFromDb,
+                  page,
+                  limit,
+                  results: [
+                    {
+                      ...resultingCollectionAttributes,
+                      urn: `urn:decentraland:mumbai:collections-v2:${dbCollection.contract_address}`,
+                    },
+                  ],
+                },
+                ok: true,
+              })
+              expect(Collection.findAll).toHaveBeenCalledWith({
+                q,
+                assignee,
+                status,
+                type,
+                sort,
+                isPublished: true,
+                offset: page - 1, // it's the offset
+                limit,
+                thirdPartyIds: [],
+                remoteIds: [],
+                itemTags: [itemTag.toLowerCase(), itemTag2.toLowerCase()],
+              })
+            })
+        })
+      })
+
+      describe('and not sending any pagination params ', () => {
+        beforeEach(() => {
+          url = `/collections`
+          ;(Collection.findAll as jest.Mock)
+            .mockResolvedValueOnce([dbCollection])
+            .mockResolvedValueOnce([])
+        })
+        it('should respond with all the collections with the URN and the legacy response', () => {
+          return server
+            .get(buildURL(url))
+            .set(createAuthHeaders('get', url))
+            .expect(200)
+            .then((response: any) => {
+              expect(response.body).toEqual({
+                data: [
+                  {
+                    ...resultingCollectionAttributes,
+                    urn: `urn:decentraland:mumbai:collections-v2:${dbCollection.contract_address}`,
+                  },
+                ],
+                ok: true,
+              })
+            })
+        })
       })
     })
   })

--- a/src/Collection/Collection.router.spec.ts
+++ b/src/Collection/Collection.router.spec.ts
@@ -857,7 +857,6 @@ describe('Collection router', () => {
         ;(Collection.findByContractAddresses as jest.Mock).mockResolvedValueOnce(
           []
         )
-        // url = '/collections?q=name&isPublished=true'
         ;(collectionAPI.fetchCollections as jest.Mock).mockResolvedValueOnce([])
         thirdPartyAPIMock.fetchThirdParties.mockResolvedValueOnce([])
       })

--- a/src/Collection/Collection.router.ts
+++ b/src/Collection/Collection.router.ts
@@ -245,7 +245,7 @@ export class CollectionRouter extends Router {
     const eth_address = req.auth.ethAddress
     const canRequestCollections = await isCommitteeMember(eth_address)
 
-    if (!canRequestCollections && !(q && isPublished)) {
+    if (!canRequestCollections && !(q && isPublished === 'true')) {
       throw new HTTPError(
         'Unauthorized',
         { eth_address },


### PR DESCRIPTION
This PR does the following:
- Add a migration to add `pg_trgm` extension and set the `similarity_threshold` to 0.5 (0.3 is the default)
- Allows calls to `/collections` if it's being asked with `q` and `isPublished=true` parameters
- Adds the `%` operator to do the fuzzy search in the Collections query.

Closes #709