### PR TITLE
fix: remove the CREATE trgm extension from migration

### DIFF
--- a/migrations/1695119925617_add-trgm-extension.ts
+++ b/migrations/1695119925617_add-trgm-extension.ts
@@ -4,10 +4,5 @@ import { MigrationBuilder, ColumnDefinitions } from 'node-pg-migrate'
 export const shorthands: ColumnDefinitions | undefined = undefined
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
-  pgm.addExtension('pg_trgm', { ifNotExists: true })
   pgm.sql('SET pg_trgm.similarity_threshold = 0.5')
-}
-
-export async function down(pgm: MigrationBuilder): Promise<void> {
-  pgm.dropExtension('pg_trgm')
 }


### PR DESCRIPTION
The extension might be the reason why the service is failing to deploy, let's remove it and re-try