### PR TITLE
feat: new endpoints  (delete and get) for newsletter

### DIFF
--- a/src/Newsletter/Newsletter.model.spec.ts
+++ b/src/Newsletter/Newsletter.model.spec.ts
@@ -29,7 +29,7 @@ describe('Newsletter', () => {
     expect(result).toEqual(mockResponse)
   })
 
-  it('should return null if the API call results in an error', async () => {
+  it('should return null if the subscription API call results in an error', async () => {
     const mockEmail = 'test@example.com'
     ;(nodefetch as unknown as jest.Mock).mockRejectedValue(new Error('API Error'))
 
@@ -37,13 +37,71 @@ describe('Newsletter', () => {
     expect(result).toBeNull()
   })
 
-  it('should return null if there is an exception', async () => {
+  it('should return null if there is an exception during the subscription', async () => {
     const mockEmail = 'test@example.com'
     ;(nodefetch as unknown as jest.Mock).mockImplementation(() => {
       throw new Error('Exception while fetching')
     })
 
     const result = await Newsletter.subscribe(mockEmail)
+    expect(result).toBeNull()
+  })
+
+  it('should delete the email successfully', async () => {
+    const mockSubscriptionId = 'testSubscrionId'
+    const mockResponse = { success: true }
+    ;(nodefetch as unknown as jest.Mock).mockResolvedValue({
+      json: jest.fn().mockResolvedValue(mockResponse),
+    })
+
+    const result = await Newsletter.deleteSubscription(mockSubscriptionId)
+    expect(result).toEqual(mockResponse)
+  })
+
+  it('should return null if the delete API call results in an error', async () => {
+    const mockSubscriptionId = 'testSubscrionId'
+    ;(nodefetch as unknown as jest.Mock).mockRejectedValue(new Error('API Error'))
+
+    const result = await Newsletter.deleteSubscription(mockSubscriptionId)
+    expect(result).toBeNull()
+  })
+
+  it('should return null if there is an exception during the delete', async () => {
+    const mockSubscriptionId = 'testSubscrionId'
+    ;(nodefetch as unknown as jest.Mock).mockImplementation(() => {
+      throw new Error('Exception while fetching')
+    })
+
+    const result = await Newsletter.deleteSubscription(mockSubscriptionId)
+    expect(result).toBeNull()
+  })
+
+  it('should get the email successfully', async () => {
+    const mockSubscriptionId = 'testSubscrionId'
+    const mockResponse = { success: true }
+    ;(nodefetch as unknown as jest.Mock).mockResolvedValue({
+      json: jest.fn().mockResolvedValue(mockResponse),
+    })
+
+    const result = await Newsletter.getSubscription(mockSubscriptionId)
+    expect(result).toEqual(mockResponse)
+  })
+
+  it('should return null if the get API call results in an error', async () => {
+    const mockSubscriptionId = 'testSubscrionId'
+    ;(nodefetch as unknown as jest.Mock).mockRejectedValue(new Error('API Error'))
+
+    const result = await Newsletter.getSubscription(mockSubscriptionId)
+    expect(result).toBeNull()
+  })
+
+  it('should return null if there is an exception during the get', async () => {
+    const mockSubscriptionId = 'testSubscrionId'
+    ;(nodefetch as unknown as jest.Mock).mockImplementation(() => {
+      throw new Error('Exception while fetching')
+    })
+
+    const result = await Newsletter.getSubscription(mockSubscriptionId)
     expect(result).toBeNull()
   })
 })

--- a/src/Newsletter/Newsletter.model.spec.ts
+++ b/src/Newsletter/Newsletter.model.spec.ts
@@ -21,7 +21,7 @@ describe('Newsletter', () => {
   it('should subscribe the email successfully', async () => {
     const mockEmail = 'test@example.com'
     const mockResponse = { success: true }
-    ;(nodefetch as unknown as jest.Mock).mockResolvedValue({
+    ;((nodefetch as unknown) as jest.Mock).mockResolvedValue({
       json: jest.fn().mockResolvedValue(mockResponse),
     })
 
@@ -31,7 +31,9 @@ describe('Newsletter', () => {
 
   it('should return null if the subscription API call results in an error', async () => {
     const mockEmail = 'test@example.com'
-    ;(nodefetch as unknown as jest.Mock).mockRejectedValue(new Error('API Error'))
+    ;((nodefetch as unknown) as jest.Mock).mockRejectedValue(
+      new Error('API Error')
+    )
 
     const result = await Newsletter.subscribe(mockEmail)
     expect(result).toBeNull()
@@ -39,7 +41,7 @@ describe('Newsletter', () => {
 
   it('should return null if there is an exception during the subscription', async () => {
     const mockEmail = 'test@example.com'
-    ;(nodefetch as unknown as jest.Mock).mockImplementation(() => {
+    ;((nodefetch as unknown) as jest.Mock).mockImplementation(() => {
       throw new Error('Exception while fetching')
     })
 
@@ -50,9 +52,7 @@ describe('Newsletter', () => {
   it('should delete the email successfully', async () => {
     const mockSubscriptionId = 'testSubscrionId'
     const mockResponse = { success: true }
-    ;(nodefetch as unknown as jest.Mock).mockResolvedValue({
-      json: jest.fn().mockResolvedValue(mockResponse),
-    })
+    ;((nodefetch as unknown) as jest.Mock).mockResolvedValue(mockResponse)
 
     const result = await Newsletter.deleteSubscription(mockSubscriptionId)
     expect(result).toEqual(mockResponse)
@@ -60,7 +60,9 @@ describe('Newsletter', () => {
 
   it('should return null if the delete API call results in an error', async () => {
     const mockSubscriptionId = 'testSubscrionId'
-    ;(nodefetch as unknown as jest.Mock).mockRejectedValue(new Error('API Error'))
+    ;((nodefetch as unknown) as jest.Mock).mockRejectedValue(
+      new Error('API Error')
+    )
 
     const result = await Newsletter.deleteSubscription(mockSubscriptionId)
     expect(result).toBeNull()
@@ -68,7 +70,7 @@ describe('Newsletter', () => {
 
   it('should return null if there is an exception during the delete', async () => {
     const mockSubscriptionId = 'testSubscrionId'
-    ;(nodefetch as unknown as jest.Mock).mockImplementation(() => {
+    ;((nodefetch as unknown) as jest.Mock).mockImplementation(() => {
       throw new Error('Exception while fetching')
     })
 
@@ -79,7 +81,7 @@ describe('Newsletter', () => {
   it('should get the email successfully', async () => {
     const mockSubscriptionId = 'testSubscrionId'
     const mockResponse = { success: true }
-    ;(nodefetch as unknown as jest.Mock).mockResolvedValue({
+    ;((nodefetch as unknown) as jest.Mock).mockResolvedValue({
       json: jest.fn().mockResolvedValue(mockResponse),
     })
 
@@ -89,7 +91,9 @@ describe('Newsletter', () => {
 
   it('should return null if the get API call results in an error', async () => {
     const mockSubscriptionId = 'testSubscrionId'
-    ;(nodefetch as unknown as jest.Mock).mockRejectedValue(new Error('API Error'))
+    ;((nodefetch as unknown) as jest.Mock).mockRejectedValue(
+      new Error('API Error')
+    )
 
     const result = await Newsletter.getSubscription(mockSubscriptionId)
     expect(result).toBeNull()
@@ -97,7 +101,7 @@ describe('Newsletter', () => {
 
   it('should return null if there is an exception during the get', async () => {
     const mockSubscriptionId = 'testSubscrionId'
-    ;(nodefetch as unknown as jest.Mock).mockImplementation(() => {
+    ;((nodefetch as unknown) as jest.Mock).mockImplementation(() => {
       throw new Error('Exception while fetching')
     })
 

--- a/src/Newsletter/Newsletter.model.ts
+++ b/src/Newsletter/Newsletter.model.ts
@@ -1,4 +1,4 @@
-import nodefetch from 'node-fetch'
+import nodefetch, { Response } from 'node-fetch'
 import { env } from 'decentraland-commons'
 import { SubscriptionResponse } from './Newsletter.types'
 
@@ -40,7 +40,9 @@ export namespace Newsletter {
     }
   }
 
-  export async function deleteSubscription(subscriptionId: string): Promise<SubscriptionResponse | null> {
+  export async function deleteSubscription(
+    subscriptionId: string
+  ): Promise<Response | null> {
     try {
       const options = {
         method: 'DELETE',
@@ -54,14 +56,16 @@ export namespace Newsletter {
         options
       )
 
-      return response.json()
+      return response
     } catch (error) {
       console.error(error)
       return null
     }
   }
 
-  export async function getSubscription(subscriptionId: string): Promise<SubscriptionResponse | null> {
+  export async function getSubscription(
+    subscriptionId: string
+  ): Promise<SubscriptionResponse | null> {
     try {
       const options = {
         method: 'GET',

--- a/src/Newsletter/Newsletter.model.ts
+++ b/src/Newsletter/Newsletter.model.ts
@@ -39,4 +39,43 @@ export namespace Newsletter {
       return null
     }
   }
+
+  export async function deleteSubscription(subscriptionId: string): Promise<void> {
+    try {
+      const options = {
+        method: 'DELETE',
+        headers: {
+          Accept: 'application/json',
+          Authorization: `Bearer ${NEWSLETTER_SERVICE_API_KEY}`,
+        },
+      }
+      await nodefetch(
+        `${NEWSLETTER_SERVICE_URL}/publications/${NEWSLETTER_PUBLICATION_ID}/subscriptions/${subscriptionId}`,
+        options
+      )
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  export async function getSubscription(subscriptionId: string): Promise<SubscriptionResponse | null> {
+    try {
+      const options = {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+          Authorization: `Bearer ${NEWSLETTER_SERVICE_API_KEY}`,
+        },
+      }
+      const response = await nodefetch(
+        `${NEWSLETTER_SERVICE_URL}/publications/${NEWSLETTER_PUBLICATION_ID}/subscriptions/${subscriptionId}`,
+        options
+      )
+
+      return response.json()
+    } catch (error) {
+      console.error(error)
+      return null
+    }
+  }
 }

--- a/src/Newsletter/Newsletter.model.ts
+++ b/src/Newsletter/Newsletter.model.ts
@@ -40,7 +40,7 @@ export namespace Newsletter {
     }
   }
 
-  export async function deleteSubscription(subscriptionId: string): Promise<void> {
+  export async function deleteSubscription(subscriptionId: string): Promise<SubscriptionResponse | null> {
     try {
       const options = {
         method: 'DELETE',
@@ -49,12 +49,15 @@ export namespace Newsletter {
           Authorization: `Bearer ${NEWSLETTER_SERVICE_API_KEY}`,
         },
       }
-      await nodefetch(
+      const response = await nodefetch(
         `${NEWSLETTER_SERVICE_URL}/publications/${NEWSLETTER_PUBLICATION_ID}/subscriptions/${subscriptionId}`,
         options
       )
+
+      return response.json()
     } catch (error) {
       console.error(error)
+      return null
     }
   }
 

--- a/src/Newsletter/Newsletter.router.ts
+++ b/src/Newsletter/Newsletter.router.ts
@@ -6,10 +6,22 @@ import { Newsletter } from './Newsletter.model'
 export class NewsletterRouter extends Router {
   mount() {
     this.router.post('/newsletter', server.handleRequest(this.subscribe))
+    this.router.delete('/newsletter/:subscriptionId', server.handleRequest(this.deleteSubscription))
+    this.router.get('/newsletter/:subscriptionId', server.handleRequest(this.getSubscription))
   }
 
   async subscribe(req: Request) {
     const { email, source } = req.body
     return Newsletter.subscribe(email, source)
+  }
+
+  async deleteSubscription(req: Request) {
+    const subscriptionId = server.extractFromReq(req, 'subscriptionId')
+    return Newsletter.deleteSubscription(subscriptionId)
+  }
+
+  async getSubscription(req: Request) {
+    const subscriptionId = server.extractFromReq(req, 'subscriptionId')
+    return Newsletter.getSubscription(subscriptionId)
   }
 }


### PR DESCRIPTION
This PR add these 2 new endpoing for Newsletter:
- `deleteSubscription`: Deletes an existing subscription.
- `getSubscription`: Obtain an existing subscription.