### PR TITLE
fix: remove the utm_campaign field from subscriptions

### DIFF
--- a/src/Newsletter/Newsletter.model.ts
+++ b/src/Newsletter/Newsletter.model.ts
@@ -24,7 +24,6 @@ export namespace Newsletter {
           reactivate_existing: true,
           send_welcome_email: false,
           utm_source: source,
-          utm_campaign: 'Builder',
           utm_medium: 'organic',
         }),
       }


### PR DESCRIPTION
Since the `utm_campaign` field is not adding any value and, in addition, is generating confusion now that we're using the subscriptions endpoints from different sources (builder, explorer...), we've decided to remove it.