### PR TITLE
Add realm name to the /about endpoint. 

### DIFF
--- a/src/Project/Project.router.ts
+++ b/src/Project/Project.router.ts
@@ -366,7 +366,7 @@ export class ProjectRouter extends Router {
         skybox: {
           fixedHour: 36000
         },
-        realmName: `web-editor-${projectId}`
+        realmName: `web-editor-${projectId.split('-').slice(-1)}`
       },
       content: {
         healthy: true,

--- a/src/Project/Project.router.ts
+++ b/src/Project/Project.router.ts
@@ -366,7 +366,7 @@ export class ProjectRouter extends Router {
         skybox: {
           fixedHour: 36000
         },
-        realmName: `builder-preview-${projectId}`
+        realmName: `web-editor-${projectId}`
       },
       content: {
         healthy: true,

--- a/src/Project/Project.router.ts
+++ b/src/Project/Project.router.ts
@@ -360,6 +360,13 @@ export class ProjectRouter extends Router {
         scenesUrn: [
           `urn:decentraland:entity:${ENTITY_HASH}?=&baseUrl=${BUILDER_SERVER_URL}/v1/projects/${projectId}/contents/`,
         ],
+        minimap: {
+          enabled: false
+        },
+        skybox: {
+          fixedHour: 36000
+        },
+        realmName: `builder-preview-${projectId}`
       },
       content: {
         healthy: true,


### PR DESCRIPTION
Add realmName because the unity-renderer needs it in order to check for new realms when the position changes.

Set skybox fixed time.

Set minimap in false