### PR TITLE
fix: create layout from new component, fallback to legacy one

### DIFF
--- a/src/Scene/SDK7Scene.ts
+++ b/src/Scene/SDK7Scene.ts
@@ -16,7 +16,8 @@ export class SDK7Scene {
 
   getLayout(): Layout {
     return this.getComposite().components.find(
-      ({ name }) => name === 'inspector::Scene'
+      ({ name }) =>
+        name === 'inspector::SceneMetadata' || name === 'inspector::Scene'
     )?.data[0].json.layout
   }
 


### PR DESCRIPTION
Handle both the new and old components. This should not break because the editor still saves both components for retrocompat issues, but there are some broken scenes in .zone that somehow got to a state that they only have the new component and they cannot be previewed due to this. This would fix the issue for them.