### PR TITLE
feat: Add granular CORS

### DIFF
--- a/src/Analytics/Analytics.router.ts
+++ b/src/Analytics/Analytics.router.ts
@@ -1,23 +1,35 @@
 import cacheControl from 'express-cache-controller'
 import { server } from 'decentraland-server'
 import { Router } from '../common/Router'
+import { withCors } from '../middleware/cors'
 import { Analytics } from './Analytics.model'
 import { Request } from 'express'
 
 export class AnalyticsRouter extends Router {
   mount() {
     /**
+     * CORS for the OPTIONS header
+     */
+    this.router.options('/analytics/weekly', withCors)
+    this.router.options('/analytics/status', withCors)
+
+    /**
      * Get weekly stats
      */
     this.router.get(
       '/analytics/weekly',
+      withCors,
       cacheControl({ maxAge: 43200, public: true }),
       server.handleRequest(this.getWeekly)
     ),
       /**
        * Get status
        */
-      this.router.get('/analytics/status', server.handleRequest(this.getStatus))
+      this.router.get(
+        '/analytics/status',
+        withCors,
+        server.handleRequest(this.getStatus)
+      )
   }
 
   async getWeekly(req: Request) {

--- a/src/App/App.router.ts
+++ b/src/App/App.router.ts
@@ -2,10 +2,20 @@ import { server } from 'decentraland-server'
 import { env } from 'decentraland-commons'
 
 import { Router } from '../common/Router'
+import { withPermissiveCors } from '../middleware/cors'
 
 export class AppRouter extends Router {
   mount() {
-    this.router.get('/info', server.handleRequest(this.getVersion))
+    /**
+     * CORS for the OPTIONS header
+     */
+    this.router.options('/info', withPermissiveCors)
+
+    this.router.get(
+      '/info',
+      withPermissiveCors,
+      server.handleRequest(this.getVersion)
+    )
   }
 
   getVersion() {

--- a/src/Asset/Asset.router.ts
+++ b/src/Asset/Asset.router.ts
@@ -2,6 +2,7 @@ import { Request } from 'express'
 import { server } from 'decentraland-server'
 import { hashV1 } from '@dcl/hashing'
 import { Router } from '../common/Router'
+import { withCors } from '../middleware/cors'
 import {
   withModelExists,
   asMiddleware,
@@ -22,10 +23,18 @@ export class AssetRouter extends Router {
     )
 
     /**
+     * CORS for the OPTIONS header
+     */
+    this.router.options('/assetPacks/:assetPackId/assets/:id/files', withCors)
+    this.router.options('/assets/:id', withCors)
+    this.router.options('/assets', withCors)
+
+    /**
      * Upload the files for each asset in an asset pack
      */
     this.router.post(
       '/assetPacks/:assetPackId/assets/:id/files',
+      withCors,
       withAuthentication,
       withAssetPackExists,
       withAssetPackAuthorization,
@@ -44,6 +53,7 @@ export class AssetRouter extends Router {
      */
     this.router.get(
       '/assets/:id',
+      withCors,
       withAssetExists,
       server.handleRequest(this.getAsset)
     )
@@ -51,7 +61,7 @@ export class AssetRouter extends Router {
     /**
      * Get a multiple assets
      */
-    this.router.get('/assets', server.handleRequest(this.getAssets))
+    this.router.get('/assets', withCors, server.handleRequest(this.getAssets))
   }
 
   async assetBelongsToPackMiddleware(req: Request) {

--- a/src/AssetPack/AssetPack.router.ts
+++ b/src/AssetPack/AssetPack.router.ts
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid'
 import express from 'express'
 import { ILoggerComponent } from '@well-known-components/interfaces'
 
+import { withCors } from '../middleware/cors'
 import { Router } from '../common/Router'
 import { HTTPError, STATUS_CODES } from '../common/HTTPError'
 import { getValidator } from '../utils/validator'
@@ -59,10 +60,18 @@ export class AssetPackRouter extends Router {
     const withAssetPackAuthorization = withModelAuthorization(AssetPack)
 
     /**
+     * CORS for the OPTIONS header
+     */
+    this.router.options('/assetPacks', withCors)
+    this.router.options('/assetPacks/:id', withCors)
+    this.router.options('/assetPacks/:id/thumbnail', withCors)
+
+    /**
      * Get all asset packs
      */
     this.router.get(
       '/assetPacks',
+      withCors,
       withPermissiveAuthentication,
       withLowercaseQueryParams(['owner']),
       asyncHandler(this.getAssetPacks)
@@ -73,6 +82,7 @@ export class AssetPackRouter extends Router {
      */
     this.router.get(
       '/assetPacks/:id',
+      withCors,
       withPermissiveAuthentication,
       server.handleRequest(this.getAssetPack)
     )
@@ -82,6 +92,7 @@ export class AssetPackRouter extends Router {
      */
     this.router.put(
       '/assetPacks/:id',
+      withCors,
       withAuthentication,
       server.handleRequest(this.upsertAssetPack)
     )
@@ -91,6 +102,7 @@ export class AssetPackRouter extends Router {
      */
     this.router.delete(
       '/assetPacks/:id',
+      withCors,
       withAuthentication,
       withAssetPackExists,
       withAssetPackAuthorization,
@@ -102,6 +114,7 @@ export class AssetPackRouter extends Router {
      */
     this.router.post(
       '/assetPacks/:id/thumbnail',
+      withCors,
       withAuthentication,
       withAssetPackExists,
       withAssetPackAuthorization,

--- a/src/Collection/Collection.router.ts
+++ b/src/Collection/Collection.router.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express'
 import { server } from 'decentraland-server'
 import { omit } from 'decentraland-commons/dist/utils'
+import { withCors } from '../middleware/cors'
 import { Router } from '../common/Router'
 import { HTTPError, STATUS_CODES } from '../common/HTTPError'
 import { getValidator } from '../utils/validator'
@@ -87,10 +88,23 @@ export class CollectionRouter extends Router {
     const withLowercasedAddress = withLowercasedParams(['address'])
 
     /**
+     * CORS for the OPTIONS header
+     */
+    this.router.options('/collections', withCors)
+    this.router.options('/:address/collections', withCors)
+    this.router.options('/collections/:id', withCors)
+    this.router.options('/collections/:id/publish', withCors)
+    this.router.options('/collections/:id/tos', withCors)
+    this.router.options('/collections/:id/lock', withCors)
+    this.router.options('/collections/:id/approvalData', withCors)
+    this.router.options('/addresses', withCors)
+
+    /**
      * Returns all collections
      */
     this.router.get(
       '/collections',
+      withCors,
       withPermissiveAuthentication,
       server.handleRequest(this.getCollections)
     )
@@ -100,6 +114,7 @@ export class CollectionRouter extends Router {
      */
     this.router.get(
       '/:address/collections',
+      withCors,
       withAuthentication,
       withLowercasedAddress,
       server.handleRequest(this.getAddressCollections)
@@ -110,6 +125,7 @@ export class CollectionRouter extends Router {
      */
     this.router.get(
       '/collections/:id',
+      withCors,
       withAuthentication,
       withCollectionExists,
       server.handleRequest(this.getCollection)
@@ -120,6 +136,7 @@ export class CollectionRouter extends Router {
      */
     this.router.post(
       '/collections/:id/publish',
+      withCors,
       withAuthentication,
       withCollectionExists,
       server.handleRequest(this.publishCollection)
@@ -130,6 +147,7 @@ export class CollectionRouter extends Router {
      */
     this.router.post(
       '/collections/:id/tos',
+      withCors,
       withAuthentication,
       withCollectionExists,
       server.handleRequest(this.saveTOS)
@@ -140,6 +158,7 @@ export class CollectionRouter extends Router {
      */
     this.router.post(
       '/collections/:id/lock',
+      withCors,
       withAuthentication,
       withCollectionExists,
       withCollectionAuthorization,
@@ -151,6 +170,7 @@ export class CollectionRouter extends Router {
      */
     this.router.get(
       '/collections/:id/approvalData',
+      withCors,
       withAuthentication,
       withCollectionExists,
       server.handleRequest(this.getApprovalData)
@@ -162,6 +182,7 @@ export class CollectionRouter extends Router {
      */
     this.router.put(
       '/collections/:id',
+      withCors,
       withAuthentication,
       withSchemaValidation(upsertCollectionSchema),
       server.handleRequest(this.upsertCollection)
@@ -172,6 +193,7 @@ export class CollectionRouter extends Router {
      */
     this.router.delete(
       '/collections/:id',
+      withCors,
       withAuthentication,
       withCollectionExists,
       withCollectionAuthorization,
@@ -183,6 +205,7 @@ export class CollectionRouter extends Router {
      */
     this.router.get(
       '/addresses',
+      withCors,
       server.handleRequest(this.getAddressesCollections)
     )
   }

--- a/src/Committee/Committee.router.ts
+++ b/src/Committee/Committee.router.ts
@@ -2,14 +2,24 @@ import { utils } from 'decentraland-commons'
 import { server } from 'decentraland-server'
 
 import { Router } from '../common/Router'
+import { withCors } from '../middleware/cors'
 import { collectionAPI } from '../ethereum/api/collection'
 
 export class CommitteeRouter extends Router {
   mount() {
     /**
+     * CORS for the OPTIONS header
+     */
+    this.router.options('/committee', withCors)
+
+    /**
      * Returns the addresses for the current committee
      */
-    this.router.get('/committee', server.handleRequest(this.getCommittee))
+    this.router.get(
+      '/committee',
+      withCors,
+      server.handleRequest(this.getCommittee)
+    )
   }
 
   async getCommittee() {

--- a/src/Curation/Curation.router.ts
+++ b/src/Curation/Curation.router.ts
@@ -4,6 +4,7 @@ import { Router } from '../common/Router'
 import { HTTPError, STATUS_CODES } from '../common/HTTPError'
 import { withAuthentication, AuthRequest } from '../middleware'
 import { isCommitteeMember } from '../Committee'
+import { withCors } from '../middleware/cors'
 import { collectionAPI } from '../ethereum/api/collection'
 import { thirdPartyAPI } from '../ethereum/api/thirdParty'
 import { getValidator } from '../utils/validator'
@@ -40,38 +41,55 @@ export class CurationRouter extends Router {
     //   - /collections/:id/curation -> /collectionCurations/:id
     //   - /items/:id/curation -> /itemCurations/:id
     //   - etc
+
+    /**
+     * CORS for the OPTIONS header
+     */
+    this.router.options('/curations', withCors)
+    this.router.options('/collectionCuration/:id/itemsStats', withCors)
+    this.router.options('/collections/:id/itemCurations', withCors)
+    this.router.options('/collections/:id/curation', withCors)
+    this.router.options('/collections/:id/curation/post', withCors)
+    this.router.options('/items/:id/curation', withCors)
+
     this.router.get(
       '/curations',
+      withCors,
       withAuthentication,
       server.handleRequest(this.getCollectionCurations)
     )
 
     this.router.get(
       '/collectionCuration/:id/itemsStats',
+      withCors,
       withAuthentication,
       server.handleRequest(this.getCollectionCurationItemStats)
     )
 
     this.router.get(
       '/collections/:id/itemCurations',
+      withCors,
       withAuthentication,
       server.handleRequest(this.getCollectionItemCurations)
     )
 
     this.router.get(
       '/collections/:id/curation',
+      withCors,
       withAuthentication,
       server.handleRequest(this.getCollectionCuration)
     )
 
     this.router.patch(
       '/collections/:id/curation',
+      withCors,
       withAuthentication,
       server.handleRequest(this.updateCollectionCuration)
     )
 
     this.router.post(
       '/collections/:id/curation',
+      withCors,
       withAuthentication,
       server.handleRequest(this.insertCollectionCuration)
     )
@@ -84,18 +102,21 @@ export class CurationRouter extends Router {
 
     this.router.get(
       '/items/:id/curation',
+      withCors,
       withAuthentication,
       server.handleRequest(this.getItemCuration)
     )
 
     this.router.patch(
       '/items/:id/curation',
+      withCors,
       withAuthentication,
       server.handleRequest(this.updateItemCuration)
     )
 
     this.router.post(
       '/items/:id/curation',
+      withCors,
       withAuthentication,
       server.handleRequest(this.insertItemCuration)
     )

--- a/src/Curation/Curation.router.ts
+++ b/src/Curation/Curation.router.ts
@@ -96,6 +96,7 @@ export class CurationRouter extends Router {
 
     this.router.post(
       '/collections/:id/curation/post',
+      withCors,
       withAuthentication,
       server.handleRequest(this.createCurationNewAssigneePost)
     )

--- a/src/Deployment/Deployment.router.ts
+++ b/src/Deployment/Deployment.router.ts
@@ -1,6 +1,7 @@
 import { server } from 'decentraland-server'
 
 import { Router } from '../common/Router'
+import { withCors } from '../middleware/cors'
 import { HTTPError } from '../common/HTTPError'
 import { getValidator } from '../utils/validator'
 import {
@@ -24,10 +25,17 @@ const withDeploymentAuthorization = withModelAuthorization(Deployment)
 export class DeploymentRouter extends Router {
   mount() {
     /**
+     * CORS for the OPTIONS header
+     */
+    this.router.options('/deployments', withCors)
+    this.router.options('/projects/:id/deployment', withCors)
+
+    /**
      * Get all deployments
      */
     this.router.get(
       '/deployments',
+      withCors,
       withAuthentication,
       server.handleRequest(this.getDeployments)
     )
@@ -37,6 +45,7 @@ export class DeploymentRouter extends Router {
      */
     this.router.get(
       '/projects/:id/deployment',
+      withCors,
       withAuthentication,
       withProjectExists,
       withProjectAuthorization,
@@ -48,6 +57,7 @@ export class DeploymentRouter extends Router {
      */
     this.router.put(
       '/projects/:id/deployment',
+      withCors,
       withAuthentication,
       withProjectExists,
       withProjectAuthorization,
@@ -59,6 +69,7 @@ export class DeploymentRouter extends Router {
      */
     this.router.delete(
       '/projects/:id/deployment',
+      withCors,
       withAuthentication,
       withProjectExists,
       withProjectAuthorization,

--- a/src/Forum/Forum.router.ts
+++ b/src/Forum/Forum.router.ts
@@ -3,6 +3,7 @@ import { Router } from '../common/Router'
 import { HTTPError, STATUS_CODES } from '../common/HTTPError'
 import { getValidator } from '../utils/validator'
 import { withModelExists, withModelAuthorization } from '../middleware'
+import { withCors } from '../middleware/cors'
 import { withAuthentication, AuthRequest } from '../middleware/authentication'
 import { isErrorWithMessage } from '../utils/errors'
 import {
@@ -42,10 +43,16 @@ export class ForumRouter extends Router {
     )
 
     /**
+     * CORS for the OPTIONS header
+     */
+    this.router.options('/collections/:id/post', withCors)
+
+    /**
      * Post a new thread to the forum
      */
     this.router.post(
       '/collections/:id/post',
+      withCors,
       withAuthentication,
       withCollectionExists,
       withCollectionAuthorization,

--- a/src/Item/Item.router.ts
+++ b/src/Item/Item.router.ts
@@ -4,6 +4,7 @@ import { server } from 'decentraland-server'
 import { env } from 'decentraland-commons'
 import { omit } from 'decentraland-commons/dist/utils'
 import { Router } from '../common/Router'
+import { withCors } from '../middleware/cors'
 import { HTTPError, STATUS_CODES } from '../common/HTTPError'
 import { collectionAPI } from '../ethereum/api/collection'
 import { Bridge } from '../ethereum/api/Bridge'
@@ -86,10 +87,23 @@ export class ItemRouter extends Router {
     const withLowercasedAddress = withLowercasedParams(['address'])
 
     /**
+     * CORS for the OPTIONS header
+     */
+    this.router.options('/items', withCors)
+    this.router.options('/:address/items', withCors)
+    this.router.options('/items/:id', withCors)
+    this.router.options('/collections/:id/items', withCors)
+    this.router.options('/items/:idOrURN', withCors)
+    this.router.options('/items/:id/files', withCors)
+    this.router.options('/items/:id/videos', withCors)
+    this.router.options('/items/:collectionAddress/:itemId/contents', withCors)
+
+    /**
      * Returns all items
      */
     this.router.get(
       '/items',
+      withCors,
       withAuthentication,
       server.handleRequest(this.getItems)
     )
@@ -99,6 +113,7 @@ export class ItemRouter extends Router {
      */
     this.router.get(
       '/:address/items',
+      withCors,
       withAuthentication,
       withLowercasedAddress,
       server.handleRequest(this.getAddressItems)
@@ -109,6 +124,7 @@ export class ItemRouter extends Router {
      */
     this.router.get(
       '/items/:id',
+      withCors,
       withAuthentication,
       withItemExists,
       server.handleRequest(this.getItem)
@@ -119,6 +135,7 @@ export class ItemRouter extends Router {
      */
     this.router.get(
       '/collections/:id/items',
+      withCors,
       withAuthentication,
       withCollectionExist,
       server.handleRequest(this.getCollectionItems)
@@ -130,6 +147,7 @@ export class ItemRouter extends Router {
      */
     this.router.put(
       '/items/:idOrURN',
+      withCors,
       withAuthentication,
       withSchemaValidation(upsertItemSchema),
       server.handleRequest(this.upsertItem)
@@ -140,6 +158,7 @@ export class ItemRouter extends Router {
      */
     this.router.delete(
       '/items/:id',
+      withCors,
       withAuthentication,
       withItemExists,
       withItemAuthorization,
@@ -151,6 +170,7 @@ export class ItemRouter extends Router {
      */
     this.router.post(
       '/items/:id/files',
+      withCors,
       withAuthentication,
       withItemExists,
       withItemAuthorization,
@@ -165,6 +185,7 @@ export class ItemRouter extends Router {
      */
     this.router.post(
       '/items/:id/videos',
+      withCors,
       withAuthentication,
       withItemExists,
       withItemAuthorization,
@@ -177,6 +198,7 @@ export class ItemRouter extends Router {
 
     this.router.get(
       '/items/:collectionAddress/:itemId/contents',
+      withCors,
       withLowercasedParams(['collectionAddress', 'itemId']),
       withValidContractAddress('collectionAddress'),
       withValidItemId('itemId'),

--- a/src/LAND/LAND.router.ts
+++ b/src/LAND/LAND.router.ts
@@ -4,6 +4,7 @@ import { Request } from 'express'
 //@ts-ignore
 import * as contentHash from 'content-hash'
 import fetch, { Response as FetchResponse } from 'node-fetch'
+import { withCors } from '../middleware/cors'
 import { HTTPError, STATUS_CODES } from '../common/HTTPError'
 import { Router } from '../common/Router'
 import { getCID } from '../utils/cid'
@@ -18,13 +19,21 @@ const INDEX_FILE = 'index.html'
 
 export class LANDRouter extends Router {
   mount() {
+    /**
+     * CORS for the OPTIONS header
+     */
+    this.router.options('/lands/redirectionHashes', withCors)
+    this.router.options('/lands/:coords/redirection', withCors)
+
     this.router.get(
       '/lands/redirectionHashes',
+      withCors,
       server.handleRequest(this.getRedirectionHashes)
     )
 
     this.router.post(
       '/lands/:coords/redirection',
+      withCors,
       server.handleRequest(this.uploadRedirection)
     )
   }

--- a/src/Manifest/Manifest.router.ts
+++ b/src/Manifest/Manifest.router.ts
@@ -2,6 +2,7 @@ import { server } from 'decentraland-server'
 import { Request, Response } from 'express'
 
 import { Router } from '../common/Router'
+import { withCors, withPermissiveCors } from '../middleware/cors'
 import { addInmutableCacheControlHeader } from '../common/headers'
 import { HTTPError, STATUS_CODES } from '../common/HTTPError'
 import { getValidator } from '../utils/validator'
@@ -40,10 +41,20 @@ export class ManifestRouter extends Router {
     })
 
     /**
+     * CORS for the OPTIONS header
+     */
+    this.router.options('/projects/:id/manifest', withPermissiveCors)
+    this.router.options('/manifests', withCors)
+    this.router.options('/publics/:id/manifest', withPermissiveCors)
+    this.router.options('/templates/:id/manifest', withPermissiveCors)
+    this.router.options('/pools/:id/manifest', withPermissiveCors)
+
+    /**
      * Returns the manifest of a project
      */
     this.router.get(
       '/projects/:id/manifest',
+      withPermissiveCors,
       withAuthentication,
       withProjectExists,
       withProjectAuthorization,
@@ -55,6 +66,7 @@ export class ManifestRouter extends Router {
      */
     this.router.get(
       '/manifests',
+      withCors,
       withAuthentication,
       server.handleRequest(this.getManifests)
     )
@@ -64,6 +76,7 @@ export class ManifestRouter extends Router {
      */
     this.router.get(
       '/publics/:id/manifest',
+      withPermissiveCors,
       withProjectExists,
       this.getProjectManifest
     )
@@ -73,6 +86,7 @@ export class ManifestRouter extends Router {
      */
     this.router.get(
       '/templates/:id/manifest',
+      withPermissiveCors,
       withTemplateExists,
       this.getProjectManifest
     )
@@ -82,6 +96,7 @@ export class ManifestRouter extends Router {
      */
     this.router.get(
       '/pools/:id/manifest',
+      withPermissiveCors,
       withPublishedProjectExists,
       this.getPoolManifest
     )
@@ -92,6 +107,7 @@ export class ManifestRouter extends Router {
      */
     this.router.put(
       '/projects/:id/manifest',
+      withCors,
       withAuthentication,
       server.handleRequest(this.upsertManifest)
     )
@@ -101,6 +117,7 @@ export class ManifestRouter extends Router {
      */
     this.router.delete(
       '/projects/:id/manifest',
+      withCors,
       withAuthentication,
       withProjectAuthorization,
       server.handleRequest(this.deleteManifest)

--- a/src/Manifest/Manifest.router.ts
+++ b/src/Manifest/Manifest.router.ts
@@ -107,7 +107,7 @@ export class ManifestRouter extends Router {
      */
     this.router.put(
       '/projects/:id/manifest',
-      withCors,
+      withPermissiveCors,
       withAuthentication,
       server.handleRequest(this.upsertManifest)
     )
@@ -117,7 +117,7 @@ export class ManifestRouter extends Router {
      */
     this.router.delete(
       '/projects/:id/manifest',
-      withCors,
+      withPermissiveCors,
       withAuthentication,
       withProjectAuthorization,
       server.handleRequest(this.deleteManifest)

--- a/src/NFT/NFT.router.ts
+++ b/src/NFT/NFT.router.ts
@@ -2,6 +2,7 @@ import { server } from 'decentraland-server'
 import { Request } from 'express'
 import Ajv from 'ajv'
 import { HTTPError, STATUS_CODES } from '../common/HTTPError'
+import { withCors } from '../middleware/cors'
 import { Router } from '../common/Router'
 import { NFTService } from './NFT.service'
 import { GetNFTsResponse, NFT } from './NFT.types'
@@ -10,9 +11,16 @@ export class NFTRouter extends Router {
   private readonly nftService = new NFTService()
 
   mount() {
-    this.router.get('/nfts', server.handleRequest(this.getNFTs))
+    /**
+     * CORS for the OPTIONS header
+     */
+    this.router.options('/nfts', withCors)
+    this.router.options('/nfts/:contractAddress/:tokenId', withCors)
+
+    this.router.get('/nfts', withCors, server.handleRequest(this.getNFTs))
     this.router.get(
       '/nfts/:contractAddress/:tokenId',
+      withCors,
       server.handleRequest(this.getNFT)
     )
   }

--- a/src/Newsletter/Newsletter.router.ts
+++ b/src/Newsletter/Newsletter.router.ts
@@ -1,13 +1,32 @@
 import { Request } from 'express'
 import { server } from 'decentraland-server'
 import { Router } from '../common/Router'
+import { withCors } from '../middleware/cors'
 import { Newsletter } from './Newsletter.model'
 
 export class NewsletterRouter extends Router {
   mount() {
-    this.router.post('/newsletter', server.handleRequest(this.subscribe))
-    this.router.delete('/newsletter/:subscriptionId', server.handleRequest(this.deleteSubscription))
-    this.router.get('/newsletter/:subscriptionId', server.handleRequest(this.getSubscription))
+    /**
+     * CORS for the OPTIONS header
+     */
+    this.router.options('/newsletter', withCors)
+    this.router.options('/newsletter/:subscriptionId', withCors)
+
+    this.router.post(
+      '/newsletter',
+      withCors,
+      server.handleRequest(this.subscribe)
+    )
+    this.router.delete(
+      '/newsletter/:subscriptionId',
+      withCors,
+      server.handleRequest(this.deleteSubscription)
+    )
+    this.router.get(
+      '/newsletter/:subscriptionId',
+      withCors,
+      server.handleRequest(this.getSubscription)
+    )
   }
 
   async subscribe(req: Request) {

--- a/src/Pool/Pool.router.ts
+++ b/src/Pool/Pool.router.ts
@@ -9,6 +9,7 @@ import {
   withAuthentication,
   withModelAuthorization,
 } from '../middleware'
+import { withCors } from '../middleware/cors'
 import { S3Project, MANIFEST_FILENAME, POOL_FILENAME, ACL } from '../S3'
 import { RequestParameters } from '../RequestParameters'
 import { Project, ProjectAttributes } from '../Project'
@@ -33,12 +34,18 @@ export class PoolRouter extends Router {
       is_deleted: false,
     })
     const withProjectAuthorization = withModelAuthorization(Project)
+    /**
+     * CORS for the OPTIONS header
+     */
+    this.router.options('/pools', withCors)
+    this.router.options('/projects/:id/pool', withCors)
 
     /**
      * Get all pools
      */
     this.router.get(
       '/pools',
+      withCors,
       withPermissiveAuthentication,
       server.handleRequest(this.getPools)
     )
@@ -48,6 +55,7 @@ export class PoolRouter extends Router {
      */
     this.router.get(
       '/projects/:id/pool',
+      withCors,
       withPermissiveAuthentication,
       server.handleRequest(this.getPool)
     )
@@ -57,6 +65,7 @@ export class PoolRouter extends Router {
      */
     this.router.put(
       '/projects/:id/pool',
+      withCors,
       withAuthentication,
       withProjectExists,
       withProjectAuthorization,

--- a/src/PoolGroup/PoolGroup.router.ts
+++ b/src/PoolGroup/PoolGroup.router.ts
@@ -1,6 +1,7 @@
 import { server } from 'decentraland-server'
 
 import { Router } from '../common/Router'
+import { withCors } from '../middleware/cors'
 import { RequestParameters } from '../RequestParameters'
 import { PoolGroup } from './PoolGroup.model'
 import { Request } from 'express'
@@ -8,9 +9,18 @@ import { Request } from 'express'
 export class PoolGroupRouter extends Router {
   mount() {
     /**
+     * CORS for the OPTIONS header
+     */
+    this.router.options('/pools/groups', withCors)
+
+    /**
      * Get all pool groups
      */
-    this.router.get('/pools/groups', server.handleRequest(this.getPoolGroups))
+    this.router.get(
+      '/pools/groups',
+      withCors,
+      server.handleRequest(this.getPoolGroups)
+    )
   }
 
   async getPoolGroups(req: Request) {

--- a/src/PoolLike/PoolLike.router.ts
+++ b/src/PoolLike/PoolLike.router.ts
@@ -2,6 +2,7 @@ import { server } from 'decentraland-server'
 
 import { Router } from '../common/Router'
 import { withAuthentication, withModelExists, AuthRequest } from '../middleware'
+import { withCors } from '../middleware/cors'
 import { RequestParameters } from '../RequestParameters'
 import { PoolLike } from './PoolLike.model'
 import { Pool } from '../Pool'
@@ -10,12 +11,17 @@ import { PoolLikeCount } from './PoolLike.types'
 export class PoolLikeRouter extends Router {
   mount() {
     const withProjectExists = withModelExists(Pool, 'id')
+    /**
+     * CORS for the OPTIONS header
+     */
+    this.router.options('/pools/:id/likes', withCors)
 
     /**
      * Returns the total likes of a pool
      */
     this.router.get(
       '/pools/:id/likes',
+      withCors,
       withProjectExists,
       server.handleRequest(this.countLikes)
     )
@@ -25,6 +31,7 @@ export class PoolLikeRouter extends Router {
      */
     this.router.put(
       '/pools/:id/likes',
+      withCors,
       withAuthentication,
       withProjectExists,
       server.handleRequest(this.likePool)
@@ -35,6 +42,7 @@ export class PoolLikeRouter extends Router {
      */
     this.router.delete(
       '/pools/:id/likes',
+      withCors,
       withAuthentication,
       withProjectExists,
       server.handleRequest(this.dislikePool)

--- a/src/Rarity/Rarity.router.ts
+++ b/src/Rarity/Rarity.router.ts
@@ -1,6 +1,7 @@
 import { server } from 'decentraland-server'
 import { Request } from 'express'
 import { Router } from '../common/Router'
+import { withCors } from '../middleware/cors'
 import { collectionAPI } from '../ethereum/api/collection'
 import { RarityFragment } from '../ethereum/api/fragments'
 import { HTTPError, STATUS_CODES } from '../common/HTTPError'
@@ -9,11 +10,25 @@ import { Currency, Rarity } from './types'
 
 export class RarityRouter extends Router {
   mount() {
+    /**
+     * CORS for the OPTIONS header
+     */
+    this.router.options('/rarities', withCors)
+    this.router.options('/rarities/:name', withCors)
+
     // Returns the available rarities.
-    this.router.get('/rarities', server.handleRequest(this.getRarities))
+    this.router.get(
+      '/rarities',
+      withCors,
+      server.handleRequest(this.getRarities)
+    )
 
     // Returns a single rarity according to the rarity name provided.
-    this.router.get('/rarities/:name', server.handleRequest(this.getRarity))
+    this.router.get(
+      '/rarities/:name',
+      withCors,
+      server.handleRequest(this.getRarity)
+    )
   }
 
   getRarities = async (): Promise<Rarity[]> => {

--- a/src/S3/S3Router.ts
+++ b/src/S3/S3Router.ts
@@ -4,6 +4,7 @@ import { hashV1 } from '@dcl/hashing'
 import { server } from 'decentraland-server'
 
 import { Router } from '../common/Router'
+import { withCors, withPermissiveCors } from '../middleware/cors'
 import { addInmutableCacheControlHeader } from '../common/headers'
 import { getBucketURL } from './s3'
 import { S3AssetPack } from './S3AssetPack'
@@ -15,25 +16,46 @@ import { getUploader } from './uploads'
 export class S3Router extends Router {
   mount() {
     /**
+     * CORS for the OPTIONS header
+     */
+    this.router.options('/storage/assetPacks/:filename', withPermissiveCors)
+    this.router.options('/storage/contents/:filename', withPermissiveCors)
+    this.router.options('/storage/contents/:filename/exists', withCors)
+    this.router.options('/storage/upload', withCors)
+
+    /**
      * Get an asset pack file by file id
      */
-    this.router.get('/storage/assetPacks/:filename', this.handleAssetPacks)
+    this.router.get(
+      '/storage/assetPacks/:filename',
+      withPermissiveCors,
+      this.handleAssetPacks
+    )
 
     /**
      * Get an asset file by file id (also contains items)
      */
-    this.router.get('/storage/contents/:filename', this.handleContents)
+    this.router.get(
+      '/storage/contents/:filename',
+      withPermissiveCors,
+      this.handleContents
+    )
 
     /**
      * Get the response headers for a file
      */
-    this.router.head('/storage/contents/:filename', this.handleContents)
+    this.router.head(
+      '/storage/contents/:filename',
+      withPermissiveCors,
+      this.handleContents
+    )
 
     /**
      * Return whether a file exists or not in the content server without downloading it
      */
     this.router.get(
       '/storage/contents/:filename/exists',
+      withCors,
       server.handleRequest(this.handleExists)
     )
 
@@ -42,6 +64,7 @@ export class S3Router extends Router {
      */
     this.router.post(
       '/storage/upload',
+      withCors,
       withAuthentication,
       getUploader({
         getFileStreamKey: async (file) => {

--- a/src/Share/Share.router.ts
+++ b/src/Share/Share.router.ts
@@ -5,6 +5,7 @@ import { env } from 'decentraland-commons'
 import { Router } from '../common/Router'
 
 import { Project } from '../Project/Project.model'
+import { withPermissiveCors } from '../middleware/cors'
 import { withSocialUserAgentDetector, SocialRequest } from '../middleware/share'
 import { Params, ElementType } from './Share.types'
 import { Pool, PoolAttributes } from '../Pool'
@@ -19,10 +20,16 @@ const BUILDER_SHARE_URL = env.get('BUILDER_SHARE_URL', BUILDER_URL)
 export class ShareRouter extends Router {
   mount() {
     /**
+     * CORS for the OPTIONS header
+     */
+    this.router.options('/share/:type(scene|pool)/:id', withPermissiveCors)
+
+    /**
      * Redirect to scene
      */
     this.router.get(
       '/share/:type(scene|pool)/:id',
+      withPermissiveCors,
       withSocialUserAgentDetector,
       asyncHandler(this.redirectToBuilder)
     )

--- a/src/ThirdParty/ThirdParty.router.ts
+++ b/src/ThirdParty/ThirdParty.router.ts
@@ -1,6 +1,7 @@
 import { server } from 'decentraland-server'
 
 import { Router } from '../common/Router'
+import { withCors } from '../middleware/cors'
 import { HTTPError, STATUS_CODES } from '../common/HTTPError'
 import { AuthRequest, withAuthentication } from '../middleware/authentication'
 import { thirdPartyAPI } from '../ethereum/api/thirdParty'
@@ -12,10 +13,17 @@ export class ThirdPartyRouter extends Router {
   private thirdPartyService = new ThirdPartyService()
   mount() {
     /**
+     * CORS for the OPTIONS header
+     */
+    this.router.options('/thirdParties', withCors)
+    this.router.options('/thirdParties/:id/slots', withCors)
+
+    /**
      * Get third party records
      */
     this.router.get(
       '/thirdParties',
+      withCors,
       withAuthentication,
       server.handleRequest(this.getThirdParties)
     )
@@ -24,6 +32,7 @@ export class ThirdPartyRouter extends Router {
      */
     this.router.get(
       '/thirdParties/:id/slots',
+      withCors,
       withAuthentication,
       server.handleRequest(this.getThirdPartyAvailableSlots)
     )
@@ -32,6 +41,7 @@ export class ThirdPartyRouter extends Router {
      */
     this.router.get(
       '/thirdParties/:id',
+      withCors,
       server.handleRequest(this.getThirdParty)
     )
   }

--- a/src/ThirdParty/ThirdParty.router.ts
+++ b/src/ThirdParty/ThirdParty.router.ts
@@ -16,6 +16,7 @@ export class ThirdPartyRouter extends Router {
      * CORS for the OPTIONS header
      */
     this.router.options('/thirdParties', withCors)
+    this.router.options('/thirdParties/:id', withCors)
     this.router.options('/thirdParties/:id/slots', withCors)
 
     /**

--- a/src/Tiers/Tiers.router.ts
+++ b/src/Tiers/Tiers.router.ts
@@ -1,14 +1,24 @@
 import { server } from 'decentraland-server'
 import { Router } from '../common/Router'
+import { withCors } from '../middleware/cors'
 import { TierFragment } from '../ethereum/api/fragments'
 import { thirdPartyAPI } from '../ethereum/api/thirdParty'
 
 export class TiersRouter extends Router {
   mount() {
     /**
+     * CORS for the OPTIONS header
+     */
+    this.router.options('/tiers/thirdParty', withCors)
+
+    /**
      * Get all third party tiers
      */
-    this.router.get('/tiers/thirdParty', server.handleRequest(this.getTiers))
+    this.router.get(
+      '/tiers/thirdParty',
+      withCors,
+      server.handleRequest(this.getTiers)
+    )
   }
 
   getTiers(): Promise<TierFragment[]> {

--- a/src/common/ExpressApp.ts
+++ b/src/common/ExpressApp.ts
@@ -1,5 +1,4 @@
 import express from 'express'
-import cors, { CorsOptions } from 'cors'
 import { collectDefaultMetrics } from 'prom-client'
 import { createTestMetricsComponent } from '@well-known-components/metrics'
 import { getDefaultHttpMetrics } from '@well-known-components/metrics/dist/http'
@@ -18,25 +17,6 @@ export class ExpressApp {
       express.urlencoded({ extended: false, limit: '2mb' }),
       express.json({ limit: '5mb' })
     )
-    return this
-  }
-
-  useCORS(origin: CorsOptions['origin'], method: string) {
-    const corsOptions: CorsOptions = {
-      origin,
-      methods: method,
-      allowedHeaders: '*',
-      exposedHeaders: [
-        'ETag',
-        'Cache-Control',
-        'Content-Language',
-        'Content-Type',
-        'Expires',
-        'Last-Modified',
-        'Pragma',
-      ],
-    }
-    this.app.use(cors(corsOptions))
     return this
   }
 

--- a/src/middleware/cors/cors.ts
+++ b/src/middleware/cors/cors.ts
@@ -1,0 +1,45 @@
+import { env } from 'decentraland-commons'
+import cors, { CorsOptions } from 'cors'
+
+let CORS_ORIGIN: string | RegExp | (string | RegExp)[] = env.get(
+  'CORS_ORIGIN',
+  '*'
+)
+const CORS_METHOD = env.get('CORS_METHOD', '*')
+
+if (CORS_ORIGIN.split(';').length > 1) {
+  CORS_ORIGIN = CORS_ORIGIN.split(';')
+    .map((origin) => origin.trim())
+    .map((origin) =>
+      origin.startsWith('regex:')
+        ? new RegExp(origin.replace('regex:', ''))
+        : origin
+    )
+} else if (CORS_ORIGIN.startsWith('regex:')) {
+  CORS_ORIGIN = new RegExp(CORS_ORIGIN.replace('regex:', ''))
+}
+
+const corsOptions: CorsOptions = {
+  origin: CORS_ORIGIN,
+  methods: CORS_METHOD,
+  allowedHeaders: '*',
+  exposedHeaders: [
+    'ETag',
+    'Cache-Control',
+    'Content-Language',
+    'Content-Type',
+    'Expires',
+    'Last-Modified',
+    'Pragma',
+  ],
+}
+
+console.log('CORS OPTIONS', corsOptions)
+
+export const withCors = cors(corsOptions)
+export const withPermissiveCors = cors({
+  origin: '*',
+  methods: '*',
+  allowedHeaders: '*',
+  exposedHeaders: '*',
+})

--- a/src/middleware/cors/index.ts
+++ b/src/middleware/cors/index.ts
@@ -1,0 +1,1 @@
+export * from './cors'

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,33 +32,11 @@ import { errorHandler } from './common/errorHandler'
 
 const SERVER_PORT = env.get('SERVER_PORT', '5000')
 const API_VERSION = env.get('API_VERSION', 'v1')
-let CORS_ORIGIN: string | RegExp | (string | RegExp)[] = env.get(
-  'CORS_ORIGIN',
-  '*'
-)
-const CORS_METHOD = env.get('CORS_METHOD', '*')
-
-if (CORS_ORIGIN.split(';').length > 1) {
-  CORS_ORIGIN = CORS_ORIGIN.split(';')
-    .map((origin) => origin.trim())
-    .map((origin) =>
-      origin.startsWith('regex:')
-        ? new RegExp(origin.replace('regex:', ''))
-        : origin
-    )
-} else if (CORS_ORIGIN.startsWith('regex:')) {
-  CORS_ORIGIN = new RegExp(CORS_ORIGIN.replace('regex:', ''))
-}
 
 export const app = new ExpressApp()
 const logs = createConsoleLogComponent()
 
-app
-  .useCORS(CORS_ORIGIN, CORS_METHOD)
-  .use(withLogger())
-  .useJSON()
-  .useVersion(API_VERSION)
-  .useMetrics()
+app.use(withLogger()).useJSON().useVersion(API_VERSION).useMetrics()
 
 // Mount routers
 new AppRouter(app).mount()


### PR DESCRIPTION
This PR removes the global CORS configuration and moves it to each router to granularly set CORS.
Not only the paths must be processed by the CORS middleware, but the OPTIONS headers as well. There are request that wouldn't require an OPTIONS handler, but the Builder send some request with the authentication header, making a preflight request which should be handled.