### PR TITLE
fix: Use JSON instead of JSONB

### DIFF
--- a/migrations/1720815210066_json-item-mapping.ts
+++ b/migrations/1720815210066_json-item-mapping.ts
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder } from 'node-pg-migrate'
+import { Item } from '../src/Item'
+
+const column = 'mappings'
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.alterColumn(Item.tableName, column, {
+    type: 'json',
+  })
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.alterColumn(Item.tableName, column, {
+    type: 'jsonb',
+  })
+}


### PR DESCRIPTION
This PR adds a new migration to use JSON instead of JSONB.
JSON stores the data as is sent to the database, preserving its order, which is important for the hashing algorithm