### PR TITLE
feat: Revert allowance of new URNs and allow new mappings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@dcl/crypto": "^3.0.1",
         "@dcl/hashing": "^1.1.0",
         "@dcl/platform-crypto-middleware": "^1.0.2",
-        "@dcl/schemas": "^11.12.0",
+        "@dcl/schemas": "^13.2.3",
         "@ethersproject/solidity": "^5.7.0",
         "@types/escape-html": "0.0.20",
         "@types/express": "^4.17.11",
@@ -1318,9 +1318,9 @@
       }
     },
     "node_modules/@dcl/schemas": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-11.12.0.tgz",
-      "integrity": "sha512-L04KTucvxSnrHDAl3/rnkzhjfZ785dSSPeKarBVfzyuw41uyQ0Mh4HVFWjX9hC+f/nMpM5Adg5udlT5efmepcA==",
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-13.2.3.tgz",
+      "integrity": "sha512-ab7iYQ/5XUCen9GC1iW70f3f/NPrTKikAWaPDcdi/llVr7tXkf6wORtKHXXM+0H8C6cKXPAYBWOWPq3qixETsQ==",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -6568,6 +6568,17 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
       "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="
+    },
+    "node_modules/decentraland-connect/node_modules/@dcl/schemas": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-11.12.0.tgz",
+      "integrity": "sha512-L04KTucvxSnrHDAl3/rnkzhjfZ785dSSPeKarBVfzyuw41uyQ0Mh4HVFWjX9hC+f/nMpM5Adg5udlT5efmepcA==",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-keywords": "^5.1.0",
+        "mitt": "^3.0.1"
+      }
     },
     "node_modules/decentraland-connect/node_modules/@noble/curves": {
       "version": "1.2.0",
@@ -17140,9 +17151,9 @@
       }
     },
     "@dcl/schemas": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-11.12.0.tgz",
-      "integrity": "sha512-L04KTucvxSnrHDAl3/rnkzhjfZ785dSSPeKarBVfzyuw41uyQ0Mh4HVFWjX9hC+f/nMpM5Adg5udlT5efmepcA==",
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-13.2.3.tgz",
+      "integrity": "sha512-ab7iYQ/5XUCen9GC1iW70f3f/NPrTKikAWaPDcdi/llVr7tXkf6wORtKHXXM+0H8C6cKXPAYBWOWPq3qixETsQ==",
       "requires": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -21202,6 +21213,17 @@
           "version": "1.10.1",
           "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
           "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="
+        },
+        "@dcl/schemas": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-11.12.0.tgz",
+          "integrity": "sha512-L04KTucvxSnrHDAl3/rnkzhjfZ785dSSPeKarBVfzyuw41uyQ0Mh4HVFWjX9hC+f/nMpM5Adg5udlT5efmepcA==",
+          "requires": {
+            "ajv": "^8.11.0",
+            "ajv-errors": "^3.0.0",
+            "ajv-keywords": "^5.1.0",
+            "mitt": "^3.0.1"
+          }
         },
         "@noble/curves": {
           "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@dcl/crypto": "^3.0.1",
     "@dcl/hashing": "^1.1.0",
     "@dcl/platform-crypto-middleware": "^1.0.2",
-    "@dcl/schemas": "^11.12.0",
+    "@dcl/schemas": "^13.2.3",
     "@ethersproject/solidity": "^5.7.0",
     "@types/escape-html": "0.0.20",
     "@types/express": "^4.17.11",

--- a/src/Collection/Collection.schema.ts
+++ b/src/Collection/Collection.schema.ts
@@ -4,7 +4,7 @@ export const collectionSchema = Object.freeze({
   type: 'object',
   properties: {
     id: { type: 'string', format: 'uuid' },
-    urn: { type: ['string', 'null'], pattern: matchers.collectionUrn },
+    urn: { type: ['string', 'null'], pattern: matchers.urn },
     name: { type: 'string', maxLength: 42 },
     eth_address: { type: 'string' },
     salt: { type: ['string', 'null'] },

--- a/src/Collection/utils.spec.ts
+++ b/src/Collection/utils.spec.ts
@@ -19,14 +19,14 @@ describe('when decoding the TP collection URN', () => {
   const collectionURNSuffix = 'a-urn-suffix'
   let fullUrn: string
 
-  describe('when the URN is not a valid item URN', () => {
+  describe('when the URN is not a valid TP URN', () => {
     beforeEach(() => {
       fullUrn = `an-invalid-urn`
     })
 
-    it('should throw indicating that the URN is not item compliant', () => {
+    it('should throw indicating that the URN is not TP compliant', () => {
       expect(() => decodeTPCollectionURN(fullUrn)).toThrow(
-        'The given item URN is not item compliant'
+        'The given collection URN is not Third Party compliant'
       )
     })
   })

--- a/src/Item/Item.errors.ts
+++ b/src/Item/Item.errors.ts
@@ -103,15 +103,3 @@ export class InvalidItemURNError extends Error {
     super('The item URN is invalid.')
   }
 }
-
-export class RequiresMappingsError extends Error {
-  constructor(public id: string) {
-    super('The item requires mappings.')
-  }
-}
-
-export class MappingNotAllowedError extends Error {
-  constructor(public id: string) {
-    super('The item does not allow mappings.')
-  }
-}

--- a/src/Item/Item.router.spec.ts
+++ b/src/Item/Item.router.spec.ts
@@ -1142,28 +1142,6 @@ describe('Item router', () => {
               }
             })
 
-            describe('and the item has mappings', () => {
-              beforeEach(() => {
-                mockThirdPartyURNExists(itemToUpsert.urn!, false)
-                itemToUpsert.mappings = [{ type: MappingType.ANY }]
-              })
-
-              it('should respond with a 400 and a message signaling that the item does not allow mappings', () => {
-                return server
-                  .put(buildURL(url))
-                  .send({ item: itemToUpsert })
-                  .set(createAuthHeaders('put', url))
-                  .expect(STATUS_CODES.badRequest)
-                  .then((response: any) => {
-                    expect(response.body).toEqual({
-                      data: { id: itemToUpsert.id },
-                      error: 'The item does not allow mappings.',
-                      ok: false,
-                    })
-                  })
-              })
-            })
-
             describe('and the URN is already in use', () => {
               beforeEach(() => {
                 mockThirdPartyURNExists(itemToUpsert.urn!, true)
@@ -1189,7 +1167,7 @@ describe('Item router', () => {
               })
             })
 
-            describe('and the URN is not in use', () => {
+            describe.only('and the URN is not in use', () => {
               let resultingItem: ResultItem
 
               beforeEach(() => {
@@ -1199,11 +1177,15 @@ describe('Item router', () => {
                     blockchain_item_id: null,
                   })
                 )
+                itemToUpsert.mappings = {
+                  mainnet: { '0x0': [{ type: MappingType.ANY }] },
+                }
                 const updatedItem = {
                   ...dbTPItem,
                   urn_suffix: itemUrnSuffix,
                   collection_id: tpCollectionMock.id,
                   eth_address: wallet.address,
+                  mappings: itemToUpsert.mappings,
                   local_content_hash:
                     'b3520ef20163848f0fc69fc6aee1f7240c7ef4960944fcd92ce2e67a62828f6f',
                 }
@@ -1259,100 +1241,6 @@ describe('Item router', () => {
                   })
                 })
             })
-          })
-        })
-      })
-    })
-
-    describe('and the item is a third party v2 item', () => {
-      let itemUrnSuffix: string
-
-      beforeEach(() => {
-        itemUrnSuffix = '1'
-        url = `/items/${dbTPItem.id}`
-        dbTPItem = { ...dbTPItem, blockchain_item_id: null }
-        itemToUpsert = utils.omit(dbTPItem, ['created_at', 'updated_at'])
-        itemToUpsert.urn = buildTPItemURN(
-          'urn:decentraland:matic:collections-linked-wearables:aThirdParty',
-          'amoy:0x74c78f5A4ab22F01d5fd08455cf0Ff5C3367535C',
-          itemUrnSuffix
-        )
-      })
-
-      describe('and the item is being inserted', () => {
-        beforeEach(() => {
-          mockItem.findOne.mockResolvedValueOnce(undefined)
-          mockItem.findByURNSuffix.mockResolvedValueOnce(undefined)
-          mockCollection.findByIds.mockResolvedValueOnce([
-            { ...tpCollectionMock, item_count: 1 },
-          ])
-          mockIsThirdPartyManager(wallet.address, true)
-        })
-
-        describe('and the item does not contains a mapping', () => {
-          beforeEach(() => {
-            itemToUpsert.mappings = null
-          })
-
-          it('should respond with a 400 and a message signaling that the mapping is required', () => {
-            return server
-              .put(buildURL(url))
-              .send({ item: itemToUpsert })
-              .set(createAuthHeaders('put', url))
-              .expect(STATUS_CODES.badRequest)
-              .then((response: any) => {
-                expect(response.body).toEqual({
-                  data: { id: itemToUpsert.id },
-                  error: 'The item requires mappings.',
-                  ok: false,
-                })
-              })
-          })
-        })
-
-        describe('and the inserting process is successful', () => {
-          beforeEach(() => {
-            itemToUpsert.mappings = [{ type: MappingType.ANY }]
-            mockItem.upsert.mockImplementation((createdItem) =>
-              Promise.resolve({
-                ...createdItem,
-                blockchain_item_id: null,
-              })
-            )
-            const updatedItem = {
-              ...dbTPItem,
-              urn_suffix: itemUrnSuffix,
-              mappings: itemToUpsert.mappings,
-              collection_id: tpCollectionMock.id,
-              eth_address: wallet.address,
-              local_content_hash:
-                'd193772da3213e696a074708e70ffc3ec6940471bbdf8ab6f0f4a9819a751d29',
-            }
-            mockThirdPartyURNExists(itemToUpsert.urn!, false)
-            resultingItem = {
-              ...toResultItem(
-                updatedItem,
-                undefined,
-                undefined,
-                tpCollectionMock
-              ),
-              updated_at: expect.stringMatching(isoDateStringMatcher),
-              created_at: expect.stringMatching(isoDateStringMatcher),
-            }
-          })
-
-          it('should respond with a 200, update the item and return the updated item', () => {
-            return server
-              .put(buildURL(url))
-              .send({ item: itemToUpsert })
-              .set(createAuthHeaders('put', url))
-              .expect(200)
-              .then((response: any) => {
-                expect(response.body).toEqual({
-                  data: resultingItem,
-                  ok: true,
-                })
-              })
           })
         })
       })

--- a/src/Item/Item.router.ts
+++ b/src/Item/Item.router.ts
@@ -46,9 +46,7 @@ import {
   InconsistentItemError,
   InvalidItemURNError,
   ItemCantBeMovedFromCollectionError,
-  MappingNotAllowedError,
   NonExistentItemError,
-  RequiresMappingsError,
   ThirdPartyItemAlreadyPublishedError,
   ThirdPartyItemInsertByURNError,
   UnauthorizedToChangeToCollectionError,
@@ -517,18 +515,6 @@ export class ItemRouter extends Router {
         )
       } else if (error instanceof InvalidItemURNError) {
         throw new HTTPError(error.message, null, STATUS_CODES.badRequest)
-      } else if (error instanceof RequiresMappingsError) {
-        throw new HTTPError(
-          error.message,
-          { id: error.id },
-          STATUS_CODES.badRequest
-        )
-      } else if (error instanceof MappingNotAllowedError) {
-        throw new HTTPError(
-          error.message,
-          { id: error.id },
-          STATUS_CODES.badRequest
-        )
       }
 
       throw error

--- a/src/Item/Item.schema.ts
+++ b/src/Item/Item.schema.ts
@@ -1,4 +1,4 @@
-import { Mapping, Rarity } from '@dcl/schemas'
+import { Mappings, Mapping, Rarity } from '@dcl/schemas'
 import { matchers } from '../common/matchers'
 import {
   animationMetricsSchema,
@@ -8,11 +8,14 @@ import { emoteSchema } from './emote/types'
 import { wearableSchema } from './wearable/types'
 import { FullItem, ItemType } from './Item.types'
 
+// Monkey patch the schema to include the discriminator
+Mapping.schema.discriminator = { propertyName: 'type' }
+
 // The schema is placed into this file to avoid a circular dependency.
 const baseItemSchema = Object.freeze({
   properties: {
     id: { type: 'string', format: 'uuid' },
-    urn: { type: ['string', 'null'], pattern: matchers.itemUrn },
+    urn: { type: ['string', 'null'], pattern: matchers.urn },
     name: { type: 'string', maxLength: 32, pattern: '^[^:]*$' },
     description: {
       type: ['string', 'null'],
@@ -41,13 +44,7 @@ const baseItemSchema = Object.freeze({
     },
     utility: { type: ['string', 'null'], maxLength: 64 },
     content_hash: { type: ['string', 'null'] },
-    mappings: {
-      type: 'array',
-      items: { ...Mapping.schema, discriminator: { propertyName: 'type' } },
-      minItems: 1,
-      maxItems: 1,
-      nullable: true,
-    },
+    mappings: { ...Mappings.schema, nullable: true },
   },
   additionalProperties: false,
   anyOf: [{ required: ['id'] }, { required: ['urn'] }],
@@ -62,7 +59,7 @@ const baseItemSchema = Object.freeze({
   ],
 })
 
-const itemSchema = Object.freeze({
+export const itemSchema = Object.freeze({
   type: 'object',
   discriminator: { propertyName: 'type' },
   required: ['type'],

--- a/src/Item/Item.service.spec.ts
+++ b/src/Item/Item.service.spec.ts
@@ -1,4 +1,3 @@
-import { MappingType } from '@dcl/schemas'
 import {
   dbCollectionMock as baseDbCollectionMock,
   dbTPCollectionMock as baseDbTPCollectionMock,
@@ -18,9 +17,7 @@ import { collectionAPI } from '../ethereum/api/collection'
 import { peerAPI } from '../ethereum/api/peer'
 import {
   ItemCantBeMovedFromCollectionError,
-  MappingNotAllowedError,
   MaximunAmountOfTagsReachedError,
-  RequiresMappingsError,
   ThirdPartyItemInsertByURNError,
 } from './Item.errors'
 import { Item, MAX_TAGS_LENGTH } from './Item.model'
@@ -251,66 +248,6 @@ describe('Item Service', () => {
             )
           })
         })
-      })
-    })
-
-    describe('and the item being upserted is a TP V2 item without a mapping', () => {
-      let tpCollectionMock: CollectionAttributes
-      let tpItemMock: ItemAttributes
-
-      beforeEach(() => {
-        tpCollectionMock = {
-          ...dbTPCollectionMock,
-          third_party_id:
-            'urn:decentraland:matic:collections-linked-wearables:aThirdParty',
-          urn_suffix: 'amoy:0x74c78f5A4ab22F01d5fd08455cf0Ff5C3367535C',
-        }
-        tpItemMock = {
-          ...dbTPItemMock,
-          urn_suffix: '1',
-          mappings: null,
-        }
-        ;(Item.findByURNSuffix as jest.Mock).mockResolvedValueOnce(undefined)
-        ;(Collection.findByIds as jest.Mock).mockResolvedValueOnce([
-          tpCollectionMock,
-        ])
-      })
-
-      it('should throw the requires mapping error', () => {
-        return expect(
-          service.upsertItem(
-            Bridge.toFullItem(tpItemMock, tpCollectionMock),
-            tpItemMock.eth_address
-          )
-        ).rejects.toThrowError(RequiresMappingsError)
-      })
-    })
-
-    describe('and the item being upserted is a TP V1 item with a mapping', () => {
-      let tpCollectionMock: CollectionAttributes
-      let tpItemMock: ItemAttributes
-
-      beforeEach(() => {
-        tpCollectionMock = {
-          ...dbTPCollectionMock,
-        }
-        tpItemMock = {
-          ...dbTPItemMock,
-          mappings: [{ type: MappingType.ANY }],
-        }
-        ;(Item.findByURNSuffix as jest.Mock).mockResolvedValueOnce(undefined)
-        ;(Collection.findByIds as jest.Mock).mockResolvedValueOnce([
-          tpCollectionMock,
-        ])
-      })
-
-      it('should throw the mapping not allowed error', () => {
-        return expect(
-          service.upsertItem(
-            Bridge.toFullItem(tpItemMock, tpCollectionMock),
-            tpItemMock.eth_address
-          )
-        ).rejects.toThrowError(MappingNotAllowedError)
       })
     })
   })

--- a/src/Item/Item.service.ts
+++ b/src/Item/Item.service.ts
@@ -19,7 +19,6 @@ import {
   decodeThirdPartyItemURN,
   getDecentralandItemURN,
   isTPCollection,
-  isTPV2ItemURN,
 } from '../utils/urn'
 import { calculateItemContentHash } from './hashes'
 import {
@@ -36,8 +35,6 @@ import {
   URNAlreadyInUseError,
   ThirdPartyItemInsertByURNError,
   MaximunAmountOfTagsReachedError,
-  RequiresMappingsError,
-  MappingNotAllowedError,
 } from './Item.errors'
 import { Item, MAX_TAGS_LENGTH } from './Item.model'
 import {
@@ -717,12 +714,6 @@ export class ItemService {
       throw new InvalidItemURNError()
     }
 
-    if (isTPV2ItemURN(item.urn) && item.mappings === null) {
-      throw new RequiresMappingsError(item.id)
-    } else if (!isTPV2ItemURN(item.urn) && item.mappings) {
-      throw new MappingNotAllowedError(item.id)
-    }
-
     // Check if the collection being used in this update or insert process is accessible by the user
     if (dbCollection) {
       if (
@@ -795,25 +786,17 @@ export class ItemService {
       ? await calculateItemContentHash(attributes, dbCollection)
       : null
 
+    console.log('Inserting attributes', attributes.mappings)
+
     const upsertedItem: ItemAttributes = await Item.upsert({
       ...attributes,
-      ...(attributes.mappings
-        ? // Stringify the JSON mappings to store it in the DB
-          ({ mappings: JSON.stringify(attributes.mappings) } as any)
-        : {}),
+      ...(attributes.mappings ? { mappings: attributes.mappings } : {}),
     })
     if (dbItem && attributes.local_content_hash) {
       // Update the Item Curation content_hash
       await ItemCuration.update(
         { content_hash: attributes.local_content_hash },
         { item_id: attributes.id, status: CurationStatus.PENDING }
-      )
-    }
-
-    // When inserting the array as string, the client returns a string, so we need to parse it back to an array
-    if (upsertedItem.mappings) {
-      upsertedItem.mappings = JSON.parse(
-        (upsertedItem.mappings as unknown) as string
       )
     }
 

--- a/src/Item/Item.types.ts
+++ b/src/Item/Item.types.ts
@@ -1,4 +1,4 @@
-import { Rarity, Mapping } from '@dcl/schemas'
+import { Mappings, Rarity } from '@dcl/schemas'
 import { ItemCurationAttributes } from '../Curation/ItemCuration'
 import { MetricsAttributes } from '../Metrics'
 import { Cheque } from '../SlotUsageCheque'
@@ -38,7 +38,7 @@ export type ItemAttributes<T = ItemType.WEARABLE> = {
   metrics: MetricsAttributes
   utility: string | null
   contents: ItemContents
-  mappings: Mapping[] | null
+  mappings: Mappings | null
   created_at: Date
   updated_at: Date
 }

--- a/src/Item/hashes.ts
+++ b/src/Item/hashes.ts
@@ -8,11 +8,7 @@ import {
 } from '@dcl/schemas'
 import { CollectionAttributes } from '../Collection'
 import { isStandardItemPublished } from '../ItemAndCollection/utils'
-import {
-  getDecentralandItemURN,
-  isTPCollection,
-  isTPV2ItemURN,
-} from '../utils/urn'
+import { getDecentralandItemURN, isTPCollection } from '../utils/urn'
 import { ItemAttributes, ItemType } from './Item.types'
 import { buildTPItemURN, isTPItem, VIDEO_PATH } from './utils'
 
@@ -124,7 +120,7 @@ function buildTPWearableEntityMetadata(
     thumbnail: THUMBNAIL_PATH,
     metrics: item.metrics,
     content: item.contents,
-    ...(isTPV2ItemURN(id) ? { mappings: item.mappings } : {}),
+    ...(item.mappings ? { mappings: item.mappings } : {}),
   }
 }
 

--- a/src/common/matchers.spec.ts
+++ b/src/common/matchers.spec.ts
@@ -1,214 +1,29 @@
 import { matchers } from './matchers'
 
-describe('when using the collection URN matcher', () => {
-  let decentralandURN: string
-
-  describe('and the urn to be checked is from a decentraland collection', () => {
-    let collectionAddress: string
-
-    beforeEach(() => {
-      collectionAddress = '0xc6d2000a7a1ddca92941f4e2b41360fe4ee2abd8'
-      decentralandURN = `urn:decentraland:mumbai:collections-v2:${collectionAddress}`
-    })
-
-    it('should match the URN', () => {
-      expect(new RegExp(matchers.collectionUrn).test(decentralandURN)).toBe(
-        true
-      )
-    })
-
-    it('should extract the network, the type and the collection address', () => {
-      const matches = new RegExp(matchers.collectionUrn).exec(decentralandURN)
-
-      expect(matches).not.toBeNull()
-      expect(matches?.groups?.protocol).toBe('mumbai')
-      expect(matches?.groups?.type).toBe('collections-v2')
-      expect(matches?.groups?.collectionAddress).toBe(collectionAddress)
-    })
-  })
-
-  describe('and the urn to be checked is from a third party v1 collection', () => {
+describe('matchers', () => {
+  describe('when the urn matchers is generated', () => {
     let decentralandURN: string
-    let thirdPartyName: string
-    let collection_id: string
+    let thirdPartyURN: string
 
     beforeEach(() => {
-      thirdPartyName = 'crypto-motors'
-      collection_id = 'some-name'
-      decentralandURN = `urn:decentraland:matic:collections-thirdparty:${thirdPartyName}:${collection_id}`
+      decentralandURN =
+        'urn:decentraland:mumbai:collections-v2:0xc6d2000a7a1ddca92941f4e2b41360fe4ee2abd8'
+      thirdPartyURN =
+        'urn:decentraland:matic:collections-thirdparty:crypto-motors:some-name'
     })
 
-    it('should match the URN', () => {
-      expect(new RegExp(matchers.collectionUrn).test(decentralandURN)).toBe(
-        true
+    it('should append the other matchers', () => {
+      expect(matchers.urn).toBe(
+        'urn:decentraland:(mainnet|goerli|sepolia|matic|mumbai|amoy):(?:collections-thirdparty:[^:|\\s]+:[^:|\\s]+|collections-v2:0x[a-fA-F0-9]{40})'
       )
     })
 
-    it('should extract the network, the type, the third party name and the collection id', () => {
-      const matches = new RegExp(matchers.collectionUrn).exec(decentralandURN)
-
-      expect(matches).not.toBeNull()
-      expect(matches?.groups?.protocol).toBe('matic')
-      expect(matches?.groups?.type).toBe('collections-thirdparty')
-      expect(matches?.groups?.thirdPartyName).toBe(thirdPartyName)
-      expect(matches?.groups?.thirdPartyCollectionId).toBe(collection_id)
-    })
-  })
-
-  describe('and the urn to be checked is from a third party v2 collection', () => {
-    let decentralandURN: string
-    let thirdPartyName: string
-    let linkedCollectionNetwork: string
-    let linkedCollectionAddress: string
-
-    beforeEach(() => {
-      thirdPartyName = 'crypto-motors'
-      linkedCollectionNetwork = 'mainnet'
-      linkedCollectionAddress = '0x74c78f5A4ab22F01d5fd08455cf0Ff5C3367535C'
-      decentralandURN = `urn:decentraland:matic:collections-linked-wearables:${thirdPartyName}:${linkedCollectionNetwork}:${linkedCollectionAddress}`
+    it('should match a decentraland URN', () => {
+      expect(new RegExp(matchers.urn).test(decentralandURN)).toBe(true)
     })
 
-    it('should match the URN', () => {
-      expect(new RegExp(matchers.collectionUrn).test(decentralandURN)).toBe(
-        true
-      )
-    })
-
-    it('should extract the network, the type, the third party name, the linked collection network and the linked collection address', () => {
-      const matches = new RegExp(matchers.collectionUrn).exec(decentralandURN)
-
-      expect(matches).not.toBeNull()
-      expect(matches?.groups?.protocol).toBe('matic')
-      expect(matches?.groups?.type).toBe('collections-linked-wearables')
-      expect(matches?.groups?.thirdPartyLinkedCollectionName).toBe(
-        thirdPartyName
-      )
-      expect(matches?.groups?.linkedCollectionNetwork).toBe(
-        linkedCollectionNetwork
-      )
-      expect(matches?.groups?.linkedCollectionContractAddress).toBe(
-        linkedCollectionAddress
-      )
-    })
-  })
-
-  describe('and the urn to be checked is invalid', () => {
-    let decentralandURN: string
-
-    beforeEach(() => {
-      decentralandURN = 'an-invalid-urn'
-    })
-
-    it('should not match the URN', () => {
-      expect(new RegExp(matchers.collectionUrn).test(decentralandURN)).toBe(
-        false
-      )
-    })
-  })
-})
-
-describe('when using the item URN matcher', () => {
-  let decentralandURN: string
-
-  describe('and the urn to be checked is from a decentraland item', () => {
-    let contractAddress: string
-    let tokenId: string
-
-    beforeEach(() => {
-      contractAddress = '0xc6d2000a7a1ddca92941f4e2b41360fe4ee2abd8'
-      tokenId = '1'
-      decentralandURN = `urn:decentraland:mumbai:collections-v2:${contractAddress}:${tokenId}`
-    })
-
-    it('should match the URN', () => {
-      expect(new RegExp(matchers.itemUrn).test(decentralandURN)).toBe(true)
-    })
-
-    it('should extract the network, the type, the collection address and the item id', () => {
-      const matches = new RegExp(matchers.itemUrn).exec(decentralandURN)
-
-      expect(matches).not.toBeNull()
-      expect(matches?.groups?.protocol).toBe('mumbai')
-      expect(matches?.groups?.type).toBe('collections-v2')
-      expect(matches?.groups?.collectionAddress).toBe(contractAddress)
-      expect(matches?.groups?.tokenId).toBe(tokenId)
-    })
-  })
-
-  describe('and the urn to be checked is from a third party v1 item', () => {
-    let thirdPartyName: string
-    let collection_id: string
-    let tokenId: string
-
-    beforeEach(() => {
-      thirdPartyName = 'crypto-motors'
-      collection_id = 'some-name'
-      tokenId = '1'
-      decentralandURN = `urn:decentraland:matic:collections-thirdparty:${thirdPartyName}:${collection_id}:${tokenId}`
-    })
-
-    it('should match the URN', () => {
-      expect(new RegExp(matchers.itemUrn).test(decentralandURN)).toBe(true)
-    })
-
-    it('should extract the network, the type, the third party name, the collection id and the item id', () => {
-      const matches = new RegExp(matchers.itemUrn).exec(decentralandURN)
-
-      expect(matches).not.toBeNull()
-      expect(matches?.groups?.protocol).toBe('matic')
-      expect(matches?.groups?.type).toBe('collections-thirdparty')
-      expect(matches?.groups?.thirdPartyName).toBe(thirdPartyName)
-      expect(matches?.groups?.thirdPartyCollectionId).toBe(collection_id)
-      expect(matches?.groups?.thirdPartyTokenId).toBe(tokenId)
-    })
-  })
-
-  describe('and the urn to be checked is from a third party v2 item', () => {
-    let thirdPartyName: string
-    let linkedCollectionNetwork: string
-    let linkedCollectionAddress: string
-    let tokenId: string
-
-    beforeEach(() => {
-      thirdPartyName = 'crypto-motors'
-      linkedCollectionNetwork = 'mainnet'
-      linkedCollectionAddress = '0x74c78f5A4ab22F01d5fd08455cf0Ff5C3367535C'
-      tokenId = '1'
-      decentralandURN = `urn:decentraland:matic:collections-linked-wearables:${thirdPartyName}:${linkedCollectionNetwork}:${linkedCollectionAddress}:${tokenId}`
-    })
-
-    it('should match the URN', () => {
-      expect(new RegExp(matchers.itemUrn).test(decentralandURN)).toBe(true)
-    })
-
-    it('should extract the network, the type, the third party name, the linked collection network, the linked collection address and the item id', () => {
-      const matches = new RegExp(matchers.itemUrn).exec(decentralandURN)
-
-      expect(matches).not.toBeNull()
-      expect(matches?.groups?.protocol).toBe('matic')
-      expect(matches?.groups?.type).toBe('collections-linked-wearables')
-      expect(matches?.groups?.thirdPartyLinkedCollectionName).toBe(
-        thirdPartyName
-      )
-      expect(matches?.groups?.linkedCollectionNetwork).toBe(
-        linkedCollectionNetwork
-      )
-      expect(matches?.groups?.linkedCollectionContractAddress).toBe(
-        linkedCollectionAddress
-      )
-      expect(matches?.groups?.thirdPartyTokenId).toBe(tokenId)
-    })
-  })
-
-  describe('and the urn to be checked is invalid', () => {
-    let decentralandURN: string
-
-    beforeEach(() => {
-      decentralandURN = 'an-invalid-urn'
-    })
-
-    it('should not match the URN', () => {
-      expect(new RegExp(matchers.itemUrn).test(decentralandURN)).toBe(false)
+    it('should match a third party URN', () => {
+      expect(new RegExp(matchers.urn).test(thirdPartyURN)).toBe(true)
     })
   })
 })

--- a/src/common/matchers.ts
+++ b/src/common/matchers.ts
@@ -1,30 +1,31 @@
 // DCL: urn:decentraland:{network}:collections-v2:{contract-address}
-// TP v1: urn:decentraland:{network}:collections-thirdparty:{third-party-name}:{collection-id}(:{item-id})?
-// TP v2: urn:decentraland:{network}:collections-linked-wearables:{third-party-name}:{{linkedCollectionNetwork}:{linkedCollectionAddress}collection-id}:some_asset_id
+//  TP: urn:decentraland:{network}:collections-thirdparty:{third-party-name}:{collection-id}(:{item-id})?
 
 const network = '(mainnet|goerli|sepolia|matic|mumbai|amoy)'
 const address = '0x[a-fA-F0-9]{40}'
+const urnSlot = '[^:|\\s]+'
+const baseURN = `urn:decentraland:${network}`
 
-const baseMatcher = 'urn:decentraland'
-const protocolMatcher =
-  '(?<protocol>mainnet|goerli|sepolia|matic|mumbai|amoy|off-chain)'
-const typeMatcher =
-  '(?<type>collections-v2|collections-thirdparty|collections-linked-wearables)'
-const collectionsSuffixMatcher =
-  '((?<=collections-v2:)(?<collectionAddress>0x[a-fA-F0-9]{40}))'
-const thirdPartyCollectionSuffixMatcher =
-  '((?<=collections-thirdparty:)(?<thirdPartyName>[^:|\\s]+)(:(?<thirdPartyCollectionId>[^:|\\s]+)))'
-const thirdPartyCollectionV2SuffixMatcher =
-  '((?<=collections-linked-wearables:)(?<thirdPartyLinkedCollectionName>[^:|\\s]+)(:(?<linkedCollectionNetwork>mainnet|sepolia|matic|amoy):(?<linkedCollectionContractAddress>0x[a-fA-F0-9]{40})))'
-const thirdPartyItemMatcher = `(:?${thirdPartyCollectionSuffixMatcher}|${thirdPartyCollectionV2SuffixMatcher})(:(?<thirdPartyTokenId>[^:|\\s]+))?`
-const collectionItemMatcher = `${collectionsSuffixMatcher}(:(?<tokenId>[^:|\\s]+))`
+const dclIdentifier = 'collections-v2'
+const tpIdentifier = `collections-thirdparty:${urnSlot}`
+
+const dclSuffix = `${dclIdentifier}:${address}`
+const tpSuffix = `${tpIdentifier}:${urnSlot}`
 
 export const matchers = {
   email:
     "[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*",
 
   network,
-  collectionUrn: `${baseMatcher}:${protocolMatcher}:${typeMatcher}:(:?${collectionsSuffixMatcher}|${thirdPartyCollectionSuffixMatcher}|${thirdPartyCollectionV2SuffixMatcher})`,
-  itemUrn: `${baseMatcher}:${protocolMatcher}:${typeMatcher}:(:?${collectionItemMatcher}|${thirdPartyItemMatcher})`,
+  urnSlot,
   address,
+  baseURN,
+
+  dclIdentifier,
+  tpIdentifier,
+
+  dclSuffix,
+  tpSuffix,
+
+  urn: `${baseURN}:(?:${tpSuffix}|${dclSuffix})`,
 }

--- a/src/utils/urn.spec.ts
+++ b/src/utils/urn.spec.ts
@@ -1,4 +1,4 @@
-import { decodeThirdPartyItemURN, URNType } from './urn'
+import { decodeThirdPartyItemURN } from './urn'
 
 describe('when decoding the an item URN', () => {
   let urn: string
@@ -27,7 +27,7 @@ describe('when decoding the an item URN', () => {
     })
   })
 
-  describe('when the URN is a valid Third Party v1 item URN', () => {
+  describe('when the URN is a valid Third Party item URN', () => {
     let thirdPartyId: string
     let collectionId: string
     let tokenId: string
@@ -43,7 +43,6 @@ describe('when decoding the an item URN', () => {
 
     it('should match the third party name, the network, the collection id and the item id', () => {
       const {
-        type,
         third_party_id,
         network: thirdPartyNetwork,
         collection_urn_suffix,
@@ -53,41 +52,7 @@ describe('when decoding the an item URN', () => {
       expect(
         `urn:decentraland:matic:collections-thirdparty:${thirdPartyId}`
       ).toEqual(third_party_id)
-      expect(type).toEqual(URNType.COLLECTIONS_THIRDPARTY)
       expect(thirdPartyNetwork).toEqual(network)
-      expect(collection_urn_suffix).toEqual(collectionId)
-      expect(item_urn_suffix).toEqual(tokenId)
-    })
-  })
-
-  describe('when the URN is a valid Third Party v2 item URN', () => {
-    let thirdPartyId: string
-    let collectionId: string
-    let tokenId: string
-    let network: string
-
-    beforeEach(() => {
-      thirdPartyId = 'crypto-motors'
-      collectionId = 'mainnet:0x74c78f5A4ab22F01d5fd08455cf0Ff5C3367535C'
-      tokenId = '1'
-      network = 'matic'
-      urn = `urn:decentraland:${network}:collections-linked-wearables:${thirdPartyId}:${collectionId}:${tokenId}`
-    })
-
-    it('should match the third party name, the network, the linked collection network, the linked collection address, the collection id and the item id', () => {
-      const {
-        type,
-        third_party_id,
-        network,
-        collection_urn_suffix,
-        item_urn_suffix,
-      } = decodeThirdPartyItemURN(urn)
-
-      expect(
-        `urn:decentraland:matic:collections-linked-wearables:${thirdPartyId}`
-      ).toEqual(third_party_id)
-      expect(type).toEqual(URNType.COLLECTIONS_THIRDPARTY_V2)
-      expect(network).toEqual(network)
       expect(collection_urn_suffix).toEqual(collectionId)
       expect(item_urn_suffix).toEqual(tokenId)
     })

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -1,5 +1,5 @@
 import Ajv from 'ajv'
-import { RangeMapping } from '@dcl/schemas'
+import { Mappings, RangeMapping } from '@dcl/schemas'
 import addFormats from 'ajv-formats'
 
 export function getValidator() {
@@ -7,10 +7,12 @@ export function getValidator() {
     removeAdditional: true,
     discriminator: true,
   })
-  ajv.addKeyword({
-    ...RangeMapping._fromLessThanOrEqualTo,
-    keyword: '_fromLessThanOrEqualTo',
-  })
+  ajv
+    .addKeyword({
+      ...RangeMapping._fromLessThanOrEqualTo,
+      keyword: '_fromLessThanOrEqualTo',
+    })
+    .addKeyword({ ...Mappings._isMappingsValid, keyword: '_isMappingsValid' })
   addFormats(ajv)
   return ajv
 }


### PR DESCRIPTION
This PR does the following:
- Reverts the use of the new URNs for the TP collections
- Changes the mappings to use the new format.