### PR TITLE
feat: Add mapping completion in curations

### DIFF
--- a/migrations/1724772165494_add-mapping-completion-to-item-curation.ts
+++ b/migrations/1724772165494_add-mapping-completion-to-item-curation.ts
@@ -1,0 +1,15 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder } from 'node-pg-migrate'
+import { ItemCuration } from '../src/Curation/ItemCuration'
+
+const columnName = 'is_mapping_complete'
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumn(ItemCuration.tableName, {
+    [columnName]: { type: 'boolean', notNull: false },
+  })
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumn(ItemCuration.tableName, columnName)
+}

--- a/spec/mocks/collections.ts
+++ b/spec/mocks/collections.ts
@@ -13,7 +13,9 @@ import {
 import { toUnixTimestamp } from '../../src/utils/parse'
 import { wallet } from './wallet'
 
-export const dbCollectionMock: CollectionAttributes = {
+export const dbCollectionMock: CollectionAttributes & {
+  is_mapping_complete: boolean
+} = {
   id: uuidv4(),
   name: 'Standard Mocked Collection',
   eth_address: wallet.address,
@@ -30,6 +32,7 @@ export const dbCollectionMock: CollectionAttributes = {
   third_party_id: null,
   linked_contract_address: null,
   linked_contract_network: null,
+  is_mapping_complete: false,
   reviewed_at: new Date(),
   created_at: new Date(),
   updated_at: new Date(),

--- a/spec/mocks/itemCuration.ts
+++ b/spec/mocks/itemCuration.ts
@@ -10,4 +10,5 @@ export const itemCurationMock: ItemCurationAttributes = {
   created_at: new Date(),
   updated_at: new Date(),
   content_hash: 'aHash',
+  is_mapping_complete: null,
 }

--- a/spec/mocks/items.ts
+++ b/spec/mocks/items.ts
@@ -24,6 +24,7 @@ import { buildTPItemURN } from '../../src/Item/utils'
 import { CollectionAttributes } from '../../src/Collection'
 import { decodeThirdPartyItemURN, isTPCollection } from '../../src/utils/urn'
 import { CatalystItem } from '../../src/ethereum/api/peer'
+import { ItemCurationAttributes } from '../../src/Curation/ItemCuration'
 import { dbCollectionMock, dbTPCollectionMock } from './collections'
 
 export type ResultItem = Omit<FullItem, 'created_at' | 'updated_at'> & {
@@ -80,7 +81,8 @@ export function asResultItem(item: ItemAttributes): ResultItem {
 export function toResultTPItem(
   itemAttributes: ItemAttributes,
   dbCollection: CollectionAttributes,
-  catalystItem?: Wearable & Partial<ThirdPartyProps>
+  catalystItem?: Wearable & Partial<ThirdPartyProps>,
+  curation?: ItemCurationAttributes
 ): ResultItem {
   if (
     !dbCollection.third_party_id ||
@@ -105,7 +107,7 @@ export function toResultTPItem(
     updated_at: itemAttributes.updated_at.toISOString(),
     is_approved: !!catalystItem,
     in_catalyst: !!catalystItem,
-    is_published: !!catalystItem,
+    is_published: !!catalystItem || !!curation,
     urn,
     blockchain_item_id: decodeThirdPartyItemURN(urn).item_urn_suffix,
     total_supply: 0,

--- a/src/Collection/Collection.model.ts
+++ b/src/Collection/Collection.model.ts
@@ -209,13 +209,15 @@ export class Collection extends Model<CollectionAttributes> {
    * - The collection has items with migrations but there are items that weren't approved and uploaded.
    */
   static isMappingCompleteTableStatement() {
-    return SQL`SELECT EXISTS (SELECT 1 FROM ${raw(
+    return SQL`SELECT NOT EXISTS (SELECT 1 FROM ${raw(
       Item.tableName
     )} as items LEFT JOIN ${raw(ItemCuration.tableName)} ON items.id = ${raw(
       ItemCuration.tableName
-    )}.item_id WHERE items.collection_id = collections.id AND ${raw(
+    )}.item_id WHERE items.collection_id = collections.id AND (${raw(
       ItemCuration.tableName
-    )}.is_mapping_complete = true) OR NOT EXISTS (SELECT 1 FROM ${raw(
+    )}.is_mapping_complete != false OR ${raw(
+      ItemCuration.tableName
+    )}.is_mapping_complete IS NULL)) OR NOT EXISTS (SELECT 1 FROM ${raw(
       Item.tableName
     )} items
         WHERE items.collection_id = collections.id)`

--- a/src/Collection/Collection.model.ts
+++ b/src/Collection/Collection.model.ts
@@ -203,6 +203,25 @@ export class Collection extends Model<CollectionAttributes> {
   }
 
   /**
+   * Builds the statement to check if the collection requires the mapping migration to be completed.
+   * The item migration will be required to be completed if:
+   * - The collection has items and any of its items don't have a migration.
+   * - The collection has items with migrations but there are items that weren't approved and uploaded.
+   */
+  static isMappingCompleteTableStatement() {
+    return SQL`SELECT EXISTS (SELECT 1 FROM ${raw(
+      Item.tableName
+    )} as items LEFT JOIN ${raw(ItemCuration.tableName)} ON items.id = ${raw(
+      ItemCuration.tableName
+    )}.item_id WHERE items.collection_id = collections.id AND ${raw(
+      ItemCuration.tableName
+    )}.is_mapping_complete = true) OR NOT EXISTS (SELECT 1 FROM ${raw(
+      Item.tableName
+    )} items
+        WHERE items.collection_id = collections.id)`
+  }
+
+  /**
    * Finds all the Collections that given parameters. It sorts and paginates the results.
    * If the status is APPROVED, the remoteIds will be the ones with `isApproved` true.
    * If the status is TO_REVIEW, UNDER_REVIEW or REJECTED, the remoteIds will be the ones with `isApproved` false.
@@ -231,7 +250,8 @@ export class Collection extends Model<CollectionAttributes> {
       SELECT collections.*, COUNT(*) OVER() as collection_count, (SELECT COUNT(*) FROM ${raw(
         Item.tableName
       )} 
-        WHERE items.collection_id = collections.id) as item_count
+        WHERE items.collection_id = collections.id) as item_count,
+        (${SQL`${this.isMappingCompleteTableStatement()}`}) as is_mapping_complete
         FROM (
           SELECT DISTINCT on (c.id) c.* FROM ${raw(Collection.tableName)} c
             ${SQL`${this.getPublishedJoinStatement(isPublished)}`}  
@@ -268,7 +288,7 @@ export class Collection extends Model<CollectionAttributes> {
 
   static findByIds(ids: string[]) {
     return this.query<CollectionWithItemCount>(SQL`
-    SELECT *, (SELECT COUNT(*) FROM ${raw(
+    SELECT *, (${SQL`${this.isMappingCompleteTableStatement()}`}) as is_mapping_complete, (SELECT COUNT(*) FROM ${raw(
       Item.tableName
     )} WHERE items.collection_id = collections.id) as item_count
       FROM ${raw(this.tableName)}

--- a/src/Collection/Collection.router.spec.ts
+++ b/src/Collection/Collection.router.spec.ts
@@ -384,6 +384,7 @@ describe('Collection router', () => {
             lock: null,
             created_at: expectedCollectionToUpsert.created_at,
             updated_at: expectedCollectionToUpsert.updated_at,
+            is_mapping_complete: false,
           }))
         })
 
@@ -483,6 +484,7 @@ describe('Collection router', () => {
               lock: null,
               created_at: expectedCollectionToUpsert.created_at,
               updated_at: expectedCollectionToUpsert.updated_at,
+              is_mapping_complete: false,
             }))
           })
 
@@ -752,6 +754,7 @@ describe('Collection router', () => {
             lock: null,
             created_at: expectedCollectionToUpsert.created_at,
             updated_at: expectedCollectionToUpsert.updated_at,
+            is_mapping_complete: false,
           }))
           ;(Collection.isValidName as jest.Mock).mockResolvedValueOnce(true)
           ;(Collection.findOne as jest.Mock).mockResolvedValueOnce({
@@ -1450,8 +1453,8 @@ describe('Collection router', () => {
               sort: CollectionSort.CREATED_AT_DESC,
               thirdPartyIds: [],
               remoteIds: [],
-              q: "text",
-              isPublished: undefined
+              q: 'text',
+              isPublished: undefined,
             })
           })
       })
@@ -2245,6 +2248,7 @@ describe('Collection router', () => {
                     created_at: expect.any(Date),
                     updated_at: expect.any(Date),
                     content_hash: item.local_content_hash,
+                    is_mapping_complete: false,
                   },
                 ])
                 expect((ItemCuration.create as jest.Mock).mock.calls).toEqual(

--- a/src/Collection/Collection.service.ts
+++ b/src/Collection/Collection.service.ts
@@ -268,6 +268,7 @@ export class CollectionService {
           content_hash: item.local_content_hash,
           created_at: now,
           updated_at: now,
+          is_mapping_complete: item.mappings !== null,
         }
         itemCurationIds.push(itemCuration.id)
         promises.push(ItemCuration.create<ItemCurationAttributes>(itemCuration))

--- a/src/Curation/ItemCuration/ItemCuration.types.ts
+++ b/src/Curation/ItemCuration/ItemCuration.types.ts
@@ -7,6 +7,7 @@ export type ItemCurationAttributes = {
   status: CurationStatus
   created_at: Date
   updated_at: Date
+  is_mapping_complete: boolean | null
 }
 
 export type ItemCurationWithTotalCount = ItemCurationAttributes & {

--- a/src/Item/Item.router.spec.ts
+++ b/src/Item/Item.router.spec.ts
@@ -292,7 +292,7 @@ describe('Item router', () => {
                 ),
                 isMappingComplete: false,
               },
-              resultTPItemPublished,
+              { ...resultTPItemPublished, is_published: true },
             ],
             ok: true,
           })
@@ -623,8 +623,11 @@ describe('Item router', () => {
           .then((response: any) => {
             expect(response.body).toEqual({
               data: [
-                { ...resultingTPItem, isMappingComplete: true },
-                resultTPItemPublished,
+                {
+                  ...resultingTPItem,
+                  isMappingComplete: true,
+                },
+                { ...resultTPItemPublished, is_published: true },
                 resultTPItemNotPublished,
               ],
               ok: true,

--- a/src/Item/Item.service.ts
+++ b/src/Item/Item.service.ts
@@ -382,7 +382,8 @@ export class ItemService {
       item = Bridge.mergeTPItem(
         dbItem,
         collection as ThirdPartyCollectionAttributes,
-        catalystItems[0]
+        catalystItems[0],
+        lastItemCuration
       )
     }
 

--- a/src/ethereum/api/Bridge.ts
+++ b/src/ethereum/api/Bridge.ts
@@ -147,7 +147,8 @@ export class Bridge {
         fullItem = Bridge.mergeTPItem(
           item,
           collection as ThirdPartyCollectionAttributes,
-          catalystItem
+          catalystItem,
+          itemCuration
         )
       } else {
         fullItem = Bridge.toFullItem(item, collection)
@@ -169,7 +170,8 @@ export class Bridge {
   static mergeTPItem(
     dbItem: ItemAttributes,
     dbCollection: ThirdPartyCollectionAttributes,
-    catalystItem?: Wearable & ThirdPartyProps
+    catalystItem?: Wearable & ThirdPartyProps,
+    lastItemCuration?: ItemCurationAttributes
   ): FullItem {
     const data = dbItem.data
     const category = data.category
@@ -192,7 +194,7 @@ export class Bridge {
       blockchain_item_id: decodeThirdPartyItemURN(urn).item_urn_suffix,
       urn,
       in_catalyst: !!catalystItem,
-      is_published: !!catalystItem,
+      is_published: !!catalystItem || !!lastItemCuration,
       // For now, items are always approved. Rejecting (or disabling) items will be done at the record level, for all collections that apply.
       is_approved: !!catalystItem,
       isMappingComplete: !!catalystItem?.mappings,


### PR DESCRIPTION
This PR adds the `is_mapping_complete` property to the returned collections. This property is set as true if:
- There are items in the collection that don't have item curations done when the item had mappings.
- There are no items in the collection.
The item curations now have a property that contains information about if the mapping was complete when the curation was created or updated, that occurs when the item is published or changes over it are pushed, meaning that the item was published with the mapping changes.