### PR TITLE
fix: Mapping completion criteria

### DIFF
--- a/spec/mocks/items.ts
+++ b/spec/mocks/items.ts
@@ -113,7 +113,8 @@ export function toResultTPItem(
     total_supply: 0,
     price: '0',
     beneficiary: constants.AddressZero,
-    isMappingComplete: !!curation?.is_mapping_complete,
+    isMappingComplete:
+      !!curation?.is_mapping_complete || !!itemAttributes.mappings,
     content_hash: null,
     catalyst_content_hash: catalystItem
       ? (catalystItem as any)?.merkleProof.entityHash

--- a/spec/mocks/items.ts
+++ b/spec/mocks/items.ts
@@ -113,7 +113,7 @@ export function toResultTPItem(
     total_supply: 0,
     price: '0',
     beneficiary: constants.AddressZero,
-    isMappingComplete: !!catalystItem?.mappings,
+    isMappingComplete: !!curation?.is_mapping_complete,
     content_hash: null,
     catalyst_content_hash: catalystItem
       ? (catalystItem as any)?.merkleProof.entityHash

--- a/src/Collection/Collection.model.ts
+++ b/src/Collection/Collection.model.ts
@@ -219,7 +219,7 @@ export class Collection extends Model<CollectionAttributes> {
           WHERE items.collection_id = collections.id
           ORDER BY items.id, item_curations.updated_at DESC) mappings_info
         WHERE mappings_info.is_mapping_complete = false
-          OR (mappings_info.is_mapping_complete IS NULL AND mappings_info.updated_at IS NOT NULL)
+          OR (mappings_info.is_mapping_complete IS NULL AND mappings_info.updated_at IS NOT NULL AND mappings_info.mappings IS NOT NULL)
           OR mappings_info.mappings IS NULL)
       OR NOT EXISTS (SELECT 1 FROM ${raw(
         Item.tableName

--- a/src/Collection/Collection.model.ts
+++ b/src/Collection/Collection.model.ts
@@ -206,19 +206,21 @@ export class Collection extends Model<CollectionAttributes> {
    * Builds the statement to check if the collection requires the mapping migration to be completed.
    * The item migration will be required to be completed if:
    * - The collection has items and any of its items don't have a migration.
-   * - The collection has items with migrations but there are items that weren't approved and uploaded.
+   * - The collection has items with mappings but there are items that weren't approved and uploaded.
    */
   static isMappingCompleteTableStatement() {
     return SQL`SELECT NOT EXISTS 
       (SELECT mappings_info.is_mapping_complete FROM
-        (SELECT DISTINCT ON (items.id) items.id, item_curations.updated_at, item_curations.is_mapping_complete
+        (SELECT DISTINCT ON (items.id) items.id, item_curations.updated_at, item_curations.is_mapping_complete, items.mappings
           FROM ${raw(Item.tableName)} items
           LEFT JOIN ${raw(
             ItemCuration.tableName
           )} item_curations ON items.id = item_curations.item_id
           WHERE items.collection_id = collections.id
           ORDER BY items.id, item_curations.updated_at DESC) mappings_info
-        WHERE mappings_info.is_mapping_complete = false OR mappings_info.is_mapping_complete IS NULL)
+        WHERE mappings_info.is_mapping_complete = false
+          OR (mappings_info.is_mapping_complete IS NULL AND mappings_info.updated_at IS NOT NULL)
+          OR mappings_info.mappings IS NULL)
       OR NOT EXISTS (SELECT 1 FROM ${raw(
         Item.tableName
       )} items WHERE items.collection_id = collections.id)`

--- a/src/Item/Item.router.spec.ts
+++ b/src/Item/Item.router.spec.ts
@@ -122,8 +122,7 @@ describe('Item router', () => {
     dbTPItemNotPublished = {
       ...dbTPItem,
       id: uuidv4(),
-      beneficiary: '',
-      urn_suffix: '',
+      urn_suffix: '23',
     }
     dbTPItemPublished = {
       ...dbTPItem,
@@ -269,6 +268,7 @@ describe('Item router', () => {
       ;(peerAPI.fetchWearables as jest.Mock).mockResolvedValueOnce([tpWearable])
       url = '/items'
     })
+
     it('should return all the items that are published with URN and the ones that are not without it', () => {
       return server
         .get(buildURL(url))
@@ -286,12 +286,14 @@ describe('Item router', () => {
               resultingTPItem,
               {
                 ...resultTPItemNotPublished,
+                price: '0',
                 urn: buildTPItemURN(
                   dbTPCollectionMock.third_party_id,
                   dbTPCollectionMock.urn_suffix,
                   dbTPItemNotPublishedMock.urn_suffix!
                 ),
                 isMappingComplete: false,
+                blockchain_item_id: '2',
               },
               { ...resultTPItemPublished, is_published: true },
             ],
@@ -615,7 +617,7 @@ describe('Item router', () => {
             [dbItemCuration]
           )
           ;(Item.findByCollectionIdAndStatus as jest.Mock).mockResolvedValueOnce(
-            [dbTPItem, dbTPItemPublished, dbTPItemNotPublished]
+            [dbTPItem, dbTPItemPublished]
           )
           url = `/collections/${dbTPCollectionMock.id}/items`
         })
@@ -634,7 +636,6 @@ describe('Item router', () => {
                 isMappingComplete: false,
               },
               { ...resultTPItemPublished, is_published: true },
-              resultTPItemNotPublished,
             ],
             ok: true,
           })
@@ -663,7 +664,6 @@ describe('Item router', () => {
           ;(Item.findByCollectionIds as jest.Mock).mockResolvedValueOnce([
             dbTPItem,
             dbTPItemPublished,
-            dbTPItemNotPublished,
           ])
           url = `/collections/${dbTPCollectionMock.id}/items`
         })
@@ -682,7 +682,6 @@ describe('Item router', () => {
                     is_published: true,
                     isMappingComplete: true,
                   },
-                  resultTPItemNotPublished,
                 ],
                 ok: true,
               })

--- a/src/ethereum/api/Bridge.ts
+++ b/src/ethereum/api/Bridge.ts
@@ -143,16 +143,12 @@ export class Bridge {
       )
 
       const collection = dbTPCollectionsIndex[item.collection_id!]
-      if (itemCuration || catalystItem) {
-        fullItem = Bridge.mergeTPItem(
-          item,
-          collection as ThirdPartyCollectionAttributes,
-          catalystItem,
-          itemCuration
-        )
-      } else {
-        fullItem = Bridge.toFullItem(item, collection)
-      }
+      fullItem = Bridge.mergeTPItem(
+        item,
+        collection as ThirdPartyCollectionAttributes,
+        catalystItem,
+        itemCuration
+      )
 
       fullItems.push(fullItem)
     }
@@ -182,6 +178,7 @@ export class Bridge {
           dbCollection.urn_suffix,
           dbItem.urn_suffix!
         )
+
     return {
       ...Bridge.toFullItem(dbItem),
       // The total supply for TP items will be 0 as they won't be minted.
@@ -197,7 +194,9 @@ export class Bridge {
       is_published: !!catalystItem || !!lastItemCuration,
       // For now, items are always approved. Rejecting (or disabling) items will be done at the record level, for all collections that apply.
       is_approved: !!catalystItem,
-      isMappingComplete: !!lastItemCuration?.is_mapping_complete,
+      // The mapping is complete if it was a curation and it was marked as complete or if doesn't and has mappings
+      isMappingComplete:
+        !!lastItemCuration?.is_mapping_complete || !!dbItem.mappings,
       content_hash: null,
       catalyst_content_hash: catalystItem
         ? (catalystItem as any).merkleProof.entityHash

--- a/src/ethereum/api/Bridge.ts
+++ b/src/ethereum/api/Bridge.ts
@@ -195,8 +195,9 @@ export class Bridge {
       // For now, items are always approved. Rejecting (or disabling) items will be done at the record level, for all collections that apply.
       is_approved: !!catalystItem,
       // The mapping is complete if it was a curation and it was marked as complete or if doesn't and has mappings
-      isMappingComplete:
-        !!lastItemCuration?.is_mapping_complete || !!dbItem.mappings,
+      isMappingComplete: lastItemCuration
+        ? !!lastItemCuration?.is_mapping_complete
+        : !!dbItem.mappings,
       content_hash: null,
       catalyst_content_hash: catalystItem
         ? (catalystItem as any).merkleProof.entityHash

--- a/src/ethereum/api/Bridge.ts
+++ b/src/ethereum/api/Bridge.ts
@@ -197,7 +197,7 @@ export class Bridge {
       is_published: !!catalystItem || !!lastItemCuration,
       // For now, items are always approved. Rejecting (or disabling) items will be done at the record level, for all collections that apply.
       is_approved: !!catalystItem,
-      isMappingComplete: !!catalystItem?.mappings,
+      isMappingComplete: !!lastItemCuration?.is_mapping_complete,
       content_hash: null,
       catalyst_content_hash: catalystItem
         ? (catalystItem as any).merkleProof.entityHash


### PR DESCRIPTION
This PR changes the mapping completion criteria:
- Collections that contain items that are not published and have migrations that are not set will be marked as incomplete.
- Items will be marked as having an incomplete mapping if they have a curation (they were published) and it's flagged as not having its mappings as complete or if they don't have mappings set.