### PR TITLE
fix: Modify unique constraint for linked contract address and network

### DIFF
--- a/migrations/1725303928904_address-network-third-party-constraint.ts
+++ b/migrations/1725303928904_address-network-third-party-constraint.ts
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MigrationBuilder } from 'node-pg-migrate'
+import { Collection } from '../src/Collection'
+
+const linkedContractAddressColumn = 'linked_contract_address'
+const linkedContractNetworkColumn = 'linked_contract_network'
+const thirdPartyId = 'third_party_id'
+const oldLinkedContractUniqueConstraintName =
+  'linkedContract_linkedNetwork_unique'
+const newLinkedContractUniqueConstraintName =
+  'linkedContract_linkedNetwork_thirdPartyId_unique'
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint(
+    Collection.tableName,
+    oldLinkedContractUniqueConstraintName
+  )
+  pgm.addConstraint(
+    Collection.tableName,
+    newLinkedContractUniqueConstraintName,
+    {
+      unique: [
+        thirdPartyId,
+        linkedContractAddressColumn,
+        linkedContractNetworkColumn,
+      ],
+    }
+  )
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropConstraint(
+    Collection.tableName,
+    newLinkedContractUniqueConstraintName
+  )
+  pgm.addConstraint(
+    Collection.tableName,
+    oldLinkedContractUniqueConstraintName,
+    {
+      unique: [linkedContractAddressColumn, linkedContractNetworkColumn],
+    }
+  )
+}


### PR DESCRIPTION
Modify the uniqueness constraint for the collections's linked contract address and network so it depends on the third party id as well.