### PR TITLE
fix: Lowercase address and return completion on creation

### DIFF
--- a/spec/mocks/collections.ts
+++ b/spec/mocks/collections.ts
@@ -111,6 +111,11 @@ export function toResultCollection(
   return omit(
     {
       ...convertCollectionDatesToISO(collection),
+      ...(collection.linked_contract_address
+        ? {
+            linked_contract_address: collection.linked_contract_address.toLowerCase(),
+          }
+        : {}),
       urn,
     },
     ['urn_suffix', 'third_party_id']

--- a/src/Collection/Collection.model.ts
+++ b/src/Collection/Collection.model.ts
@@ -209,21 +209,17 @@ export class Collection extends Model<CollectionAttributes> {
    * - The collection has items with mappings but there are items that weren't approved and uploaded.
    */
   static isMappingCompleteTableStatement() {
-    return SQL`SELECT NOT EXISTS 
+    return `SELECT NOT EXISTS 
       (SELECT mappings_info.is_mapping_complete FROM
         (SELECT DISTINCT ON (items.id) items.id, item_curations.updated_at, item_curations.is_mapping_complete, items.mappings
-          FROM ${raw(Item.tableName)} items
-          LEFT JOIN ${raw(
-            ItemCuration.tableName
-          )} item_curations ON items.id = item_curations.item_id
+          FROM ${Item.tableName} items
+          LEFT JOIN ${ItemCuration.tableName} item_curations ON items.id = item_curations.item_id
           WHERE items.collection_id = collections.id
           ORDER BY items.id, item_curations.updated_at DESC) mappings_info
         WHERE mappings_info.is_mapping_complete = false
           OR (mappings_info.is_mapping_complete IS NULL AND mappings_info.updated_at IS NOT NULL AND mappings_info.mappings IS NOT NULL)
           OR mappings_info.mappings IS NULL)
-      OR NOT EXISTS (SELECT 1 FROM ${raw(
-        Item.tableName
-      )} items WHERE items.collection_id = collections.id)`
+      OR NOT EXISTS (SELECT 1 FROM ${Item.tableName} items WHERE items.collection_id = collections.id)`
   }
 
   /**
@@ -381,7 +377,7 @@ export class Collection extends Model<CollectionAttributes> {
         attributes,
         1
       )},"updated_at" = now()
-      RETURNING *, (SELECT COUNT(*) FROM ${
+      RETURNING *, (${this.isMappingCompleteTableStatement()}) as is_mapping_complete, (SELECT COUNT(*) FROM ${
         Item.tableName
       } WHERE collections.id = items.collection_id) as item_count`,
       columnValues

--- a/src/Collection/utils.ts
+++ b/src/Collection/utils.ts
@@ -39,6 +39,11 @@ export function toFullCollection(
 
   return {
     ...utils.omit(dbCollection, ['urn_suffix', 'third_party_id']),
+    ...(dbCollection.linked_contract_address
+      ? {
+          linked_contract_address: dbCollection.linked_contract_address.toLowerCase(),
+        }
+      : {}),
     urn:
       third_party_id && urn_suffix
         ? getThirdPartyCollectionURN(third_party_id, urn_suffix)

--- a/src/Collection/utils.ts
+++ b/src/Collection/utils.ts
@@ -65,6 +65,10 @@ export function toDBCollection(
   let eth_address = isTP ? '' : collection.eth_address
   let contract_address = isTP ? null : collection.contract_address
   let salt = isTP ? '' : collection.salt
+  let linked_contract_address =
+    collection.linked_contract_address?.toLowerCase() ?? null
+  let linked_contract_network =
+    collection.linked_contract_network?.toLowerCase() ?? null
 
   return {
     ...utils.omit(collection, ['urn', 'lock', 'created_at', 'updated_at']),
@@ -72,6 +76,8 @@ export function toDBCollection(
     eth_address,
     contract_address,
     third_party_id,
+    linked_contract_address,
+    linked_contract_network,
     salt,
   }
 }


### PR DESCRIPTION
This PR does two things:
- Returns the `is_mapping_complete` status when creating a new collection.
- Lowercases the `linked_contract_address` and `linked_contract_network` when upserting a new collection.