### PR TITLE
fix: Returning is mapping complete as query

### DIFF
--- a/src/Collection/Collection.model.ts
+++ b/src/Collection/Collection.model.ts
@@ -252,7 +252,7 @@ export class Collection extends Model<CollectionAttributes> {
         Item.tableName
       )} 
         WHERE items.collection_id = collections.id) as item_count,
-        (${SQL`${this.isMappingCompleteTableStatement()}`}) as is_mapping_complete
+        (${raw(this.isMappingCompleteTableStatement())}) as is_mapping_complete
         FROM (
           SELECT DISTINCT on (c.id) c.* FROM ${raw(Collection.tableName)} c
             ${SQL`${this.getPublishedJoinStatement(isPublished)}`}  
@@ -289,7 +289,9 @@ export class Collection extends Model<CollectionAttributes> {
 
   static findByIds(ids: string[]) {
     return this.query<CollectionWithItemCount>(SQL`
-    SELECT *, (${SQL`${this.isMappingCompleteTableStatement()}`}) as is_mapping_complete, (SELECT COUNT(*) FROM ${raw(
+    SELECT *, (${raw(
+      this.isMappingCompleteTableStatement()
+    )}) as is_mapping_complete, (SELECT COUNT(*) FROM ${raw(
       Item.tableName
     )} WHERE items.collection_id = collections.id) as item_count
       FROM ${raw(this.tableName)}


### PR DESCRIPTION
Return the correct value for `is_mapping_complete`, which is now being returned as a query.