### PR TITLE
fix: Add is programmatic only when on dev

### DIFF
--- a/spec/mocks/collections.ts
+++ b/spec/mocks/collections.ts
@@ -64,7 +64,9 @@ export const collectionFragmentMock: CollectionFragment = {
   createdAt: toUnixTimestamp(dbCollectionMock.created_at),
 }
 
-export const thirdPartyFragmentMock: ThirdPartyFragment = {
+export const thirdPartyFragmentMock: ThirdPartyFragment & {
+  isProgrammatic: boolean
+} = {
   id: dbTPCollectionMock.third_party_id,
   root: 'aRoot',
   managers: [wallet.address],

--- a/src/ThirdParty/ThirdParty.service.ts
+++ b/src/ThirdParty/ThirdParty.service.ts
@@ -1,3 +1,4 @@
+import { env } from 'decentraland-commons'
 import { thirdPartyAPI } from '../ethereum/api/thirdParty'
 import { ItemCuration } from '../Curation/ItemCuration'
 import { ThirdParty, ThirdPartyMetadata } from './ThirdParty.types'
@@ -74,8 +75,10 @@ export class ThirdPartyService {
   // All third parties methods
 
   static async getThirdParties(manager?: string): Promise<ThirdParty[]> {
+    const includeProgrammatic = env.isDevelopment()
+
     const [fragments, virtualThirdParties] = await Promise.all([
-      thirdPartyAPI.fetchThirdPartiesByManager(manager),
+      thirdPartyAPI.fetchThirdPartiesByManager(includeProgrammatic, manager),
       manager
         ? this.getVirtualThirdPartiesByManager(manager)
         : ([] as ThirdParty[]),

--- a/src/ThirdParty/ThirdParty.types.ts
+++ b/src/ThirdParty/ThirdParty.types.ts
@@ -1,7 +1,7 @@
 import { LinkedContract, ThirdPartyFragment } from '../ethereum/api/fragments'
 
 export type ThirdParty = Omit<ThirdPartyFragment, 'metadata'> &
-  ThirdPartyMetadata & { published: boolean }
+  ThirdPartyMetadata & { published: boolean; isProgrammatic: boolean }
 
 export type ThirdPartyMetadata = {
   name: string

--- a/src/ThirdParty/utils.spec.ts
+++ b/src/ThirdParty/utils.spec.ts
@@ -15,7 +15,7 @@ import { VirtualThirdPartyAttributes } from './VirtualThirdParty.types'
 
 describe('when converting a third party fragment into a third party', () => {
   describe('when a complete fragment is supplied', () => {
-    let fragment: ThirdPartyFragment
+    let fragment: ThirdPartyFragment & { isProgrammatic: boolean }
 
     beforeEach(() => {
       fragment = {
@@ -56,7 +56,7 @@ describe('when converting a third party fragment into a third party', () => {
   })
 
   describe('when the third party metadata is null', () => {
-    let fragment: ThirdPartyFragment
+    let fragment: ThirdPartyFragment & { isProgrammatic: boolean }
 
     beforeEach(() => {
       fragment = {

--- a/src/ethereum/api/fragments.ts
+++ b/src/ethereum/api/fragments.ts
@@ -48,7 +48,7 @@ export const collectionFragment = () => gql`
   }
 `
 
-export const thirdPartyFragment = () => gql`
+export const thirdPartyWithProgrammaticFragment = () => gql`
   fragment thirdPartyFragment on ThirdParty {
     id
     root
@@ -56,6 +56,27 @@ export const thirdPartyFragment = () => gql`
     maxItems
     isApproved
     isProgrammatic
+    metadata {
+      type
+      thirdParty {
+        name
+        description
+        contracts {
+          address
+          network
+        }
+      }
+    }
+  }
+`
+
+export const thirdPartyFragment = () => gql`
+  fragment thirdPartyFragment on ThirdParty {
+    id
+    root
+    managers
+    maxItems
+    isApproved
     metadata {
       type
       thirdParty {
@@ -171,7 +192,6 @@ export type ThirdPartyFragment = {
   id: string
   root: string
   isApproved: boolean
-  isProgrammatic: boolean
   managers: string[]
   maxItems: string
   metadata: ThirdPartyMetadata

--- a/src/ethereum/api/thirdParty.ts
+++ b/src/ethereum/api/thirdParty.ts
@@ -6,6 +6,7 @@ import {
   thirdPartyItemFragment,
   ReceiptFragment,
   receiptsFragment,
+  thirdPartyWithProgrammaticFragment,
 } from './fragments'
 import {
   BaseGraphAPI,
@@ -32,13 +33,17 @@ const getThirdPartyQuery = () => gql`
   ${thirdPartyFragment()}
 `
 
-const getThirdPartiesByManagerQuery = () => gql`
+const getThirdPartiesByManagerQuery = (includeProgrammatic: boolean) => gql`
   query getThirdPartiesByManager(${PAGINATION_VARIABLES}, $managers: [String!]) {
-    thirdParties(${PAGINATION_ARGUMENTS}, where: { managers_contains: $managers }) {
+    thirdParties(${PAGINATION_ARGUMENTS}, where: { managers_contains_nocase: $managers }) {
       ...thirdPartyFragment
     }
   }
-  ${thirdPartyFragment()}
+  ${
+    includeProgrammatic
+      ? thirdPartyWithProgrammaticFragment()
+      : thirdPartyFragment()
+  }
 `
 
 const getThirdPartyMaxItems = () => gql`
@@ -92,10 +97,11 @@ export class ThirdPartyAPI extends BaseGraphAPI {
   }
 
   fetchThirdPartiesByManager = async (
+    includeProgrammatic: boolean,
     manager?: string
   ): Promise<ThirdPartyFragment[]> => {
     return this.paginate(['thirdParties'], {
-      query: getThirdPartiesByManagerQuery(),
+      query: getThirdPartiesByManagerQuery(includeProgrammatic),
       variables: { managers: manager ? [manager.toLowerCase()] : [] },
     })
   }


### PR DESCRIPTION
This PR changes the third party fragment to include or not the `isProgrammatic` property based on if it's in a dev or production environment.