### PR TITLE
feat: Set third party as programmatic

### DIFF
--- a/src/Collection/Collection.model.ts
+++ b/src/Collection/Collection.model.ts
@@ -17,6 +17,7 @@ type CollectionWithItemCount = CollectionAttributes & {
 
 export type CollectionWithCounts = CollectionWithItemCount & {
   collection_count: number
+  is_programmatic?: boolean
 }
 
 export type FindCollectionParams = {

--- a/src/Collection/Collection.types.ts
+++ b/src/Collection/Collection.types.ts
@@ -45,6 +45,7 @@ export type FullCollection = Omit<
   'urn_suffix' | 'third_party_id'
 > & {
   urn: string | null
+  isProgrammatic?: boolean
 }
 
 export type PublishCollectionResponse<T> = {

--- a/src/ThirdParty/ThirdParty.schema.ts
+++ b/src/ThirdParty/ThirdParty.schema.ts
@@ -1,0 +1,15 @@
+import { JSONSchema } from '@dcl/schemas'
+import { UpdateVirtualThirdPartyBody } from './ThirdParty.types'
+
+export const UpdateVirtualThirdPartyBodySchema: JSONSchema<UpdateVirtualThirdPartyBody> = {
+  type: 'object',
+  properties: {
+    isProgrammatic: {
+      type: 'boolean',
+      description: 'Defines if the third party is programmatic or not',
+      nullable: false,
+      minLength: 1,
+    },
+  },
+  required: ['isProgrammatic'],
+}

--- a/src/ThirdParty/ThirdParty.service.spec.ts
+++ b/src/ThirdParty/ThirdParty.service.spec.ts
@@ -378,3 +378,57 @@ describe('when getting all third parties of a manager', () => {
     })
   })
 })
+
+describe('when updating a virtual third party', () => {
+  describe('and the virtual third party does not exist', () => {
+    beforeEach(() => {
+      VirtualThirdPartyMock.findOne.mockResolvedValue(undefined)
+    })
+
+    it('should reject with the NonExistentThirdPartyError error', () => {
+      return expect(
+        ThirdPartyService.updateVirtualThirdParty(virtualThirdParty.id, '0x2', {
+          isProgrammatic: true,
+        })
+      ).rejects.toThrow(NonExistentThirdPartyError)
+    })
+  })
+
+  describe('and the virtual third party exists', () => {
+    beforeEach(() => {
+      VirtualThirdPartyMock.findOne.mockResolvedValue(virtualThirdParty)
+    })
+
+    describe('and the user is not a manager of the virtual third party', () => {
+      beforeEach(() => {
+        virtualThirdParty.managers = []
+      })
+
+      it('should reject with the UnauthorizedThirdPartyManagerError error', () => {
+        return expect(
+          ThirdPartyService.updateVirtualThirdParty(
+            virtualThirdParty.id,
+            '0x2',
+            { isProgrammatic: true }
+          )
+        ).rejects.toThrow(UnauthorizedThirdPartyManagerError)
+      })
+    })
+
+    describe('and the user is a manager of the virtual third party', () => {
+      beforeEach(() => {
+        virtualThirdParty.managers.push('0x2')
+      })
+
+      it('should update the virtual third party and resolve', () => {
+        return expect(
+          ThirdPartyService.updateVirtualThirdParty(
+            virtualThirdParty.id,
+            '0x2',
+            { isProgrammatic: true }
+          )
+        ).resolves.toBeUndefined()
+      })
+    })
+  })
+})

--- a/src/ThirdParty/ThirdParty.service.ts
+++ b/src/ThirdParty/ThirdParty.service.ts
@@ -1,7 +1,11 @@
 import { env } from 'decentraland-commons'
 import { thirdPartyAPI } from '../ethereum/api/thirdParty'
 import { ItemCuration } from '../Curation/ItemCuration'
-import { ThirdParty, ThirdPartyMetadata } from './ThirdParty.types'
+import {
+  ThirdParty,
+  ThirdPartyMetadata,
+  UpdateVirtualThirdPartyBody,
+} from './ThirdParty.types'
 import {
   convertThirdPartyMetadataToRawMetadata,
   convertVirtualThirdPartyToThirdParty,
@@ -142,5 +146,25 @@ export class ThirdPartyService {
     } else {
       throw new OnlyDeletableIfOnGraphError(thirdPartyId)
     }
+  }
+
+  static async updateVirtualThirdParty(
+    thirdPartyId: string,
+    manager: string,
+    updateParameters: UpdateVirtualThirdPartyBody
+  ) {
+    const virtualThirdParty = await VirtualThirdParty.findOne<VirtualThirdPartyAttributes>(
+      { id: thirdPartyId }
+    )
+    if (!virtualThirdParty) {
+      throw new NonExistentThirdPartyError(thirdPartyId)
+    }
+    if (!virtualThirdParty.managers.includes(manager)) {
+      throw new UnauthorizedThirdPartyManagerError(thirdPartyId)
+    }
+    await VirtualThirdParty.update(
+      { isProgrammatic: updateParameters.isProgrammatic },
+      { id: thirdPartyId }
+    )
   }
 }

--- a/src/ThirdParty/ThirdParty.types.ts
+++ b/src/ThirdParty/ThirdParty.types.ts
@@ -8,3 +8,7 @@ export type ThirdPartyMetadata = {
   description: string
   contracts: LinkedContract[]
 }
+
+export type UpdateVirtualThirdPartyBody = {
+  isProgrammatic: boolean
+}


### PR DESCRIPTION
This PR adds the capability to set the virtual third party as programmatic to eventually be created as one. It also adds the `is_programmatic` property to collections when retrieving all collections (for curation purposes) or when retrieving a single collection.