### PR TITLE
fix: Show collections when the user is admin

### DIFF
--- a/src/Collection/Collection.router.spec.ts
+++ b/src/Collection/Collection.router.spec.ts
@@ -71,7 +71,7 @@ import { ThirdParty } from '../ThirdParty/ThirdParty.types'
 import { isCommitteeMember } from '../Committee'
 import * as Warehouse from '../warehouse'
 import { app } from '../server'
-import { hasPublicAccess } from './access'
+import { hasPublicAccess, isAdminUser } from './access'
 import { getChequeMessageHash, toFullCollection } from './utils'
 import { Collection } from './Collection.model'
 import {
@@ -1318,6 +1318,43 @@ describe('Collection router', () => {
               })
             })
         })
+      })
+
+      describe('and not sending any pagination params ', () => {
+        beforeEach(() => {
+          url = `/collections`
+          ;(Collection.findAll as jest.Mock)
+            .mockResolvedValueOnce([dbCollection])
+            .mockResolvedValueOnce([])
+        })
+        it('should respond with all the collections with the URN and the legacy response', () => {
+          return server
+            .get(buildURL(url))
+            .set(createAuthHeaders('get', url))
+            .expect(200)
+            .then((response: any) => {
+              expect(response.body).toEqual({
+                data: [
+                  {
+                    ...resultingCollectionAttributes,
+                    urn: `${tpUrnPrefix}:${dbCollection.contract_address}`,
+                  },
+                ],
+                ok: true,
+              })
+            })
+        })
+      })
+    })
+
+    describe('and its a request from an admin user', () => {
+      beforeEach(() => {
+        ;(isAdminUser as jest.Mock).mockResolvedValueOnce(true)
+        ;(Collection.findByContractAddresses as jest.Mock).mockResolvedValueOnce(
+          []
+        )
+        ;(collectionAPI.fetchCollections as jest.Mock).mockResolvedValueOnce([])
+        ThirdPartyServiceMock.getThirdParties.mockResolvedValueOnce([])
       })
 
       describe('and not sending any pagination params ', () => {

--- a/src/Collection/Collection.router.ts
+++ b/src/Collection/Collection.router.ts
@@ -55,7 +55,7 @@ import {
   TermsOfServiceEvent,
 } from './Collection.types'
 import { upsertCollectionSchema, saveTOSSchema } from './Collection.schema'
-import { hasPublicAccess } from './access'
+import { hasPublicAccess, isAdminUser } from './access'
 import { toFullCollection, toRemoteWhereCondition } from './utils'
 import {
   AlreadyPublishedCollectionError,
@@ -269,7 +269,8 @@ export class CollectionRouter extends Router {
       type,
     } = req.query
     const eth_address = req.auth.ethAddress
-    const canRequestCollections = await isCommitteeMember(eth_address)
+    const canRequestCollections =
+      (await isCommitteeMember(eth_address)) || isAdminUser(eth_address)
 
     // If the request is not coming from a committee member, it can only request the collections that are already published and using a search term
     if (!canRequestCollections && !(q && isPublished === 'true')) {

--- a/src/Collection/access.spec.ts
+++ b/src/Collection/access.spec.ts
@@ -6,7 +6,7 @@ import {
 import { ThirdPartyService } from '../ThirdParty/ThirdParty.service'
 import { Ownable } from '../Ownable'
 import { isCommitteeMember } from '../Committee'
-import { hasAccess, hasPublicAccess } from './access'
+import { hasAccess, hasPublicAccess, isAdminUser } from './access'
 import { CollectionAttributes } from './Collection.types'
 
 jest.mock('../Committee')
@@ -133,5 +133,19 @@ describe('when getting access for a collection', () => {
         expect(await hasAccess(wallet.address, collection)).toBe(true)
       })
     })
+  })
+})
+
+describe('when checking if the user is an admin user', () => {
+  beforeEach(() => {
+    process.env.ADMIN_ADDRESSES = '0x0'
+  })
+
+  it('should return true if the user is an admin user', () => {
+    expect(isAdminUser('0x0')).toBe(true)
+  })
+
+  it('should return false if the user is not an admin user', () => {
+    expect(isAdminUser('0x1')).toBe(false)
   })
 })

--- a/src/Collection/access.ts
+++ b/src/Collection/access.ts
@@ -41,3 +41,10 @@ export function isManager(
     (manager: string) => manager.toLowerCase() === eth_address
   )
 }
+
+export function isAdminUser(eth_address: string): boolean {
+  return (
+    (process.env.ADMIN_ADDRESSES || '').split(',').includes(eth_address) ||
+    false
+  )
+}


### PR DESCRIPTION
This PR adds logic to show collections when an admin user is accessing.

This will help specific users to inspect specific collections in the Explorer.