### PR TITLE
fix: cap V8 heap explicitly to prevent OOM under Node 24

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,4 +21,8 @@ if [ $i -eq $MAX_RETRIES ]; then
   exit 1
 fi
 
-node --inspect="0.0.0.0:9229" ./dist/src/server.js || exit 1
+# Cap V8's old-space heap at ~75% of the 2 GB container limit, leaving
+# headroom for buffers, native allocations and stacks. Node 24 correctly
+# reads the cgroup v2 limit (unlike Node 18), so the auto-sized default
+# heap is otherwise too small for this service's working set.
+node --max-old-space-size=1536 ./dist/src/server.js || exit 1


### PR DESCRIPTION
## Problem

After upgrading to Node 24 (#804), the service started crashing with:

```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

These are **V8's own heap-ceiling errors** (V8 hit its configured `--max-old-space-size`), not the container's cgroup OOM-killer (which would surface as exit code 137 / SIGKILL with no V8 message).

## Root cause

Node sizes its default old-space heap at ~50% of *available* memory, where "available" comes from libuv's `uv_get_constrained_memory()`:

- **Node 18** shipped **libuv 1.44**, which **could not read cgroup v2 memory limits** and silently fell back to **host physical memory** — giving V8 a large heap ceiling, so the limit was never hit. (nodejs/node#47259)
- **Node 24** ships **libuv ≥ 1.45** (libuv#3744), which correctly reads the **container's** cgroup v2 limit and sizes the heap to ~50% of *that* — a much smaller ceiling.

Same container, same code: the service's working set now sits above the new, smaller heap ceiling, so V8 OOMs where it previously didn't. (CI passes on Node 24 because the runner isn't memory-constrained.)

## Fix

Set an explicit `--max-old-space-size=1536` in `entrypoint.sh` — ~75% of the 2 GB container limit. This makes V8's heap ceiling deterministic and independent of auto-detection, while leaving ~512 MB headroom for off-heap memory (Buffers, native allocations, thread stacks). Going higher risks the cgroup OOM-killer instead.

Also **removed `--inspect="0.0.0.0:9229"`**, which exposed the V8 debugger (a remote-code-execution vector) on all network interfaces in production.

## Verification

After deploy, exec into the container and confirm the ceiling took effect:

```sh
node -e 'console.log(require("v8").getHeapStatistics().heap_size_limit / 1024 / 1024 + " MB")'
# expect ~1536 MB
```

If OOMs persist at this ceiling, that points to genuine memory growth (to be profiled) rather than the smaller default — but this restores the pre-Node-24 behavior.

## References

- nodejs/node#47259 — Wrong memory ceiling in cgroup v2 environments
- libuv/libuv#3744 — cgroup v2 constrained-memory support
- [Red Hat — Node.js 20+ memory management in containers](https://developers.redhat.com/articles/2025/10/10/nodejs-20-memory-management-containers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)