### PR TITLE
fix(auth): harden signed fetch validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 ARG RUN
-ARG NODE_IMAGE=node:24.18.0-alpine3.24@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
 
-FROM ${NODE_IMAGE} AS builder
+FROM node:24.18.0-alpine3.24@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd AS builder
 
 WORKDIR /app
 
@@ -19,7 +18,7 @@ COPY . /app
 
 RUN npm run build
 
-FROM ${NODE_IMAGE}
+FROM node:24.18.0-alpine3.24@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
 
 WORKDIR /app
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "@apollo/client": "^3.3.9",
         "@dcl/crypto": "^3.0.1",
+        "@dcl/crypto-middleware": "^5.1.0",
         "@dcl/hashing": "^1.1.0",
-        "@dcl/platform-crypto-middleware": "^1.0.2",
         "@dcl/schemas": "^26.2.0",
         "@ethersproject/solidity": "^5.7.0",
         "@types/escape-html": "0.0.20",
@@ -1289,24 +1289,75 @@
       "resolved": "https://registry.npmjs.org/@dcl/catalyst-contracts/-/catalyst-contracts-4.0.6.tgz",
       "integrity": "sha512-Ti3YWU+cla43ai24cYgDYO4BvKamYKOBgFdasaRHm+zl3xuObSBRrDxJlOzDFmgIIZVjhutaICFyMUPyWWgcrw=="
     },
-    "node_modules/@dcl/crypto": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@dcl/crypto/-/crypto-3.4.4.tgz",
-      "integrity": "sha512-bXYPM+hh/AuNU7S2LgHDHv021mAjguwkjLvwO8XBKQRRIoZMxwH+EXizxeUpCLsf/oArjEp3cM0BnP29xV+IYQ==",
+    "node_modules/@dcl/core-commons": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@dcl/core-commons/-/core-commons-0.10.1.tgz",
+      "integrity": "sha512-iLBpIg15czlzV7No5Wzb3FyreXpqYx8YnVJ8xYKczXpl6C3eqBQoqEA02hRkd/UASbzqcPJeG1wH1wHSxYTmQw==",
       "dependencies": {
-        "@dcl/schemas": "^9.2.0",
+        "@well-known-components/interfaces": "^1.5.2"
+      }
+    },
+    "node_modules/@dcl/crypto": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@dcl/crypto/-/crypto-3.7.0.tgz",
+      "integrity": "sha512-8HSFLxnIHDeA8I/6yGAUwbCin2TX2oPn2uBLj5UmR0NFAyN5wYJCqbeolaJaIdmqN9RFjdb9ixKOY4uKF5Q2XA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@dcl/schemas": "^25.2.0",
         "eth-connect": "^6.0.3",
-        "ethereum-cryptography": "^1.0.3"
+        "ethereum-cryptography": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@dcl/crypto-middleware": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@dcl/crypto-middleware/-/crypto-middleware-5.1.0.tgz",
+      "integrity": "sha512-aiG/aInYDgL5Er+KStaIqjOmGGLlmIHSRlcAK5Jzyn+wiPU/kYiQIpMDyaIsrZ0om9HOi0M6lnqcR7ZVNpj4bA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@dcl/core-commons": "^0.10.0",
+        "@dcl/crypto": "3.7.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@dcl/crypto/node_modules/@dcl/schemas": {
-      "version": "9.15.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-9.15.0.tgz",
-      "integrity": "sha512-nip5rsOcJplNfBWeImwezuHLprM0gLW03kEeqGIvT9J6HnEBTtvIwkk9+NSt7hzFKEvWGI+C23vyNWbG3nU+SQ==",
+      "version": "25.3.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-25.3.0.tgz",
+      "integrity": "sha512-ChFW3jU3ELN6YsRvs8TZIueBR8/DDxFcWPOeCoPafjLzSRK4GX9wHYrD3Crent07C3i3tm1rX8L/2rw+S39bzQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
-        "ajv-keywords": "^5.1.0"
+        "ajv-keywords": "^5.1.0",
+        "mitt": "^3.0.1"
+      }
+    },
+    "node_modules/@dcl/crypto/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@dcl/crypto/node_modules/ethereum-cryptography": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
+      "integrity": "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.4.2",
+        "@noble/hashes": "1.4.0",
+        "@scure/bip32": "1.4.0",
+        "@scure/bip39": "1.3.0"
       }
     },
     "node_modules/@dcl/hashing": {
@@ -1317,16 +1368,6 @@
         "ethereum-cryptography": "^1.0.3",
         "ipfs-unixfs-importer": "^7.0.3",
         "multiformats": "^9.6.3"
-      }
-    },
-    "node_modules/@dcl/platform-crypto-middleware": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@dcl/platform-crypto-middleware/-/platform-crypto-middleware-1.0.2.tgz",
-      "integrity": "sha512-V99zV5XntoXmZclSj5t4S8Ioi0s7jULep7dw1UmpvnXDvozQjUNX9w5sWnXrcAalTocXHbf7bL7xK6sHHDZ0Mw==",
-      "dependencies": {
-        "@dcl/crypto": "^3.4.3",
-        "@well-known-components/fetch-component": "^2.0.2",
-        "@well-known-components/interfaces": "^1.4.2"
       }
     },
     "node_modules/@dcl/schemas": {
@@ -2744,9 +2785,10 @@
       "dev": true
     },
     "node_modules/@noble/curves": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.0.tgz",
-      "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
+      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.4.0"
       },
@@ -3131,6 +3173,66 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+    },
+    "node_modules/@scure/base": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
+      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.4.0",
+        "@noble/hashes": "~1.4.0",
+        "@scure/base": "~1.1.6"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
+      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.4.0",
+        "@scure/base": "~1.1.6"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.25.24",
@@ -4584,9 +4686,10 @@
       "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg=="
     },
     "node_modules/@well-known-components/interfaces": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@well-known-components/interfaces/-/interfaces-1.4.2.tgz",
-      "integrity": "sha512-1tkr/OhZ4UmnQiST2svKznEiJ86crV2S+AIhokhowR4MexAKWgYlmZpoP6VIcgDVPf7nu8hOtIPMQaCZ+COC0A==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@well-known-components/interfaces/-/interfaces-1.5.2.tgz",
+      "integrity": "sha512-TzKQblOci2Azczk1DZ4JL5aJW7hwq7kHrFMO4lCRMmW51bA71BtiZlq0WP72Dln067xTSoHQAU4WHCFJlGYvEQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^20.3.1",
         "@types/node-fetch": "^2.5.12",
@@ -7354,17 +7457,6 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.3.tgz",
       "integrity": "sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
-    },
-    "node_modules/ethereum-cryptography/node_modules/@scure/base": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
-      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
       "funding": [
         {
           "type": "individual",
@@ -17138,26 +17230,60 @@
       "resolved": "https://registry.npmjs.org/@dcl/catalyst-contracts/-/catalyst-contracts-4.0.6.tgz",
       "integrity": "sha512-Ti3YWU+cla43ai24cYgDYO4BvKamYKOBgFdasaRHm+zl3xuObSBRrDxJlOzDFmgIIZVjhutaICFyMUPyWWgcrw=="
     },
-    "@dcl/crypto": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@dcl/crypto/-/crypto-3.4.4.tgz",
-      "integrity": "sha512-bXYPM+hh/AuNU7S2LgHDHv021mAjguwkjLvwO8XBKQRRIoZMxwH+EXizxeUpCLsf/oArjEp3cM0BnP29xV+IYQ==",
+    "@dcl/core-commons": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@dcl/core-commons/-/core-commons-0.10.1.tgz",
+      "integrity": "sha512-iLBpIg15czlzV7No5Wzb3FyreXpqYx8YnVJ8xYKczXpl6C3eqBQoqEA02hRkd/UASbzqcPJeG1wH1wHSxYTmQw==",
       "requires": {
-        "@dcl/schemas": "^9.2.0",
+        "@well-known-components/interfaces": "^1.5.2"
+      }
+    },
+    "@dcl/crypto": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@dcl/crypto/-/crypto-3.7.0.tgz",
+      "integrity": "sha512-8HSFLxnIHDeA8I/6yGAUwbCin2TX2oPn2uBLj5UmR0NFAyN5wYJCqbeolaJaIdmqN9RFjdb9ixKOY4uKF5Q2XA==",
+      "requires": {
+        "@dcl/schemas": "^25.2.0",
         "eth-connect": "^6.0.3",
-        "ethereum-cryptography": "^1.0.3"
+        "ethereum-cryptography": "^2.0.0"
       },
       "dependencies": {
         "@dcl/schemas": {
-          "version": "9.15.0",
-          "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-9.15.0.tgz",
-          "integrity": "sha512-nip5rsOcJplNfBWeImwezuHLprM0gLW03kEeqGIvT9J6HnEBTtvIwkk9+NSt7hzFKEvWGI+C23vyNWbG3nU+SQ==",
+          "version": "25.3.0",
+          "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-25.3.0.tgz",
+          "integrity": "sha512-ChFW3jU3ELN6YsRvs8TZIueBR8/DDxFcWPOeCoPafjLzSRK4GX9wHYrD3Crent07C3i3tm1rX8L/2rw+S39bzQ==",
           "requires": {
             "ajv": "^8.11.0",
             "ajv-errors": "^3.0.0",
-            "ajv-keywords": "^5.1.0"
+            "ajv-keywords": "^5.1.0",
+            "mitt": "^3.0.1"
+          }
+        },
+        "@noble/hashes": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+          "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="
+        },
+        "ethereum-cryptography": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
+          "integrity": "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==",
+          "requires": {
+            "@noble/curves": "1.4.2",
+            "@noble/hashes": "1.4.0",
+            "@scure/bip32": "1.4.0",
+            "@scure/bip39": "1.3.0"
           }
         }
+      }
+    },
+    "@dcl/crypto-middleware": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@dcl/crypto-middleware/-/crypto-middleware-5.1.0.tgz",
+      "integrity": "sha512-aiG/aInYDgL5Er+KStaIqjOmGGLlmIHSRlcAK5Jzyn+wiPU/kYiQIpMDyaIsrZ0om9HOi0M6lnqcR7ZVNpj4bA==",
+      "requires": {
+        "@dcl/core-commons": "^0.10.0",
+        "@dcl/crypto": "3.7.0"
       }
     },
     "@dcl/hashing": {
@@ -17168,16 +17294,6 @@
         "ethereum-cryptography": "^1.0.3",
         "ipfs-unixfs-importer": "^7.0.3",
         "multiformats": "^9.6.3"
-      }
-    },
-    "@dcl/platform-crypto-middleware": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@dcl/platform-crypto-middleware/-/platform-crypto-middleware-1.0.2.tgz",
-      "integrity": "sha512-V99zV5XntoXmZclSj5t4S8Ioi0s7jULep7dw1UmpvnXDvozQjUNX9w5sWnXrcAalTocXHbf7bL7xK6sHHDZ0Mw==",
-      "requires": {
-        "@dcl/crypto": "^3.4.3",
-        "@well-known-components/fetch-component": "^2.0.2",
-        "@well-known-components/interfaces": "^1.4.2"
       }
     },
     "@dcl/schemas": {
@@ -18185,9 +18301,9 @@
       "dev": true
     },
     "@noble/curves": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.0.tgz",
-      "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
+      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
       "requires": {
         "@noble/hashes": "1.4.0"
       },
@@ -18384,6 +18500,44 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+    },
+    "@scure/base": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg=="
+    },
+    "@scure/bip32": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
+      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
+      "requires": {
+        "@noble/curves": "~1.4.0",
+        "@noble/hashes": "~1.4.0",
+        "@scure/base": "~1.1.6"
+      },
+      "dependencies": {
+        "@noble/hashes": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+          "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="
+        }
+      }
+    },
+    "@scure/bip39": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
+      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
+      "requires": {
+        "@noble/hashes": "~1.4.0",
+        "@scure/base": "~1.1.6"
+      },
+      "dependencies": {
+        "@noble/hashes": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+          "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="
+        }
+      }
     },
     "@sinclair/typebox": {
       "version": "0.25.24",
@@ -19663,9 +19817,9 @@
       }
     },
     "@well-known-components/interfaces": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@well-known-components/interfaces/-/interfaces-1.4.2.tgz",
-      "integrity": "sha512-1tkr/OhZ4UmnQiST2svKznEiJ86crV2S+AIhokhowR4MexAKWgYlmZpoP6VIcgDVPf7nu8hOtIPMQaCZ+COC0A==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@well-known-components/interfaces/-/interfaces-1.5.2.tgz",
+      "integrity": "sha512-TzKQblOci2Azczk1DZ4JL5aJW7hwq7kHrFMO4lCRMmW51bA71BtiZlq0WP72Dln067xTSoHQAU4WHCFJlGYvEQ==",
       "requires": {
         "@types/node": "^20.3.1",
         "@types/node-fetch": "^2.5.12",
@@ -21827,11 +21981,6 @@
           "version": "1.6.3",
           "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.3.tgz",
           "integrity": "sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ=="
-        },
-        "@scure/base": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
-          "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA=="
         },
         "@scure/bip32": {
           "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   "dependencies": {
     "@apollo/client": "^3.3.9",
     "@dcl/crypto": "^3.0.1",
+    "@dcl/crypto-middleware": "^5.1.0",
     "@dcl/hashing": "^1.1.0",
-    "@dcl/platform-crypto-middleware": "^1.0.2",
     "@dcl/schemas": "^26.2.0",
     "@ethersproject/solidity": "^5.7.0",
     "@types/escape-html": "0.0.20",

--- a/spec/utils.ts
+++ b/spec/utils.ts
@@ -1,4 +1,5 @@
 import { Authenticator, AuthIdentity } from '@dcl/crypto'
+import { createAuthChainHeaders } from '@dcl/crypto-middleware'
 import { Wearable } from '@dcl/schemas'
 import { Model, QueryPart } from 'decentraland-server'
 import { env } from 'decentraland-commons'
@@ -6,7 +7,6 @@ import { ethers } from 'ethers'
 import { collectionAPI } from '../src/ethereum/api/collection'
 import { peerAPI } from '../src/ethereum/api/peer'
 import { isPublished } from '../src/utils/eth'
-import { AUTH_CHAIN_HEADER_PREFIX } from '../src/middleware/authentication'
 import { CollectionFragment, ItemFragment } from '../src/ethereum/api/fragments'
 import { Collection } from '../src/Collection'
 import { ItemCuration } from '../src/Curation/ItemCuration'
@@ -39,18 +39,24 @@ export function createAuthHeaders(
   path: string = '',
   identity: AuthIdentity = wallet.identity
 ) {
-  const headers: Record<string, string> = {}
-  const endpoint = (method + ':' + path).toLowerCase()
+  const timestamp = new Date().getTime()
+  const metadata = {}
+  const endpoint = [
+    method,
+    buildURL(path).split('?')[0],
+    timestamp,
+    JSON.stringify(metadata),
+  ]
+    .join(':')
+    .toLowerCase()
   const authChain = Authenticator.signPayload(identity, endpoint)
-  for (let i = 0; i < authChain.length; i++) {
-    headers[AUTH_CHAIN_HEADER_PREFIX + i] = JSON.stringify(authChain[i])
-  }
-  return headers
+
+  return createAuthChainHeaders(authChain, timestamp, metadata)
 }
 
 /**
- * Mocks the "Date.now()" call done in the authentication middleware for tests that
- * require mocking the "Date.now" call.
+ * Mocks the expiration check's `Date.now()` call in the authentication middleware for tests that
+ * require controlling later `Date.now()` calls.
  */
 export function mockAuthenticationSignatureValidationDate() {
   const currentDate = Date.now()

--- a/src/ethereum/api/peer.ts
+++ b/src/ethereum/api/peer.ts
@@ -1,6 +1,6 @@
 import { Emote, Wearable } from '@dcl/schemas'
 import { AuthLink } from '@dcl/crypto'
-import { IFetchComponent, ILoggerComponent } from '@well-known-components/interfaces'
+import { ILoggerComponent } from '@well-known-components/interfaces'
 import { createConsoleLogComponent } from '@well-known-components/logger'
 import { createFetchComponent } from '@well-known-components/fetch-component'
 import { env } from 'decentraland-commons'
@@ -34,10 +34,8 @@ export const PEER_URL = env.get('PEER_URL', '')
 export class PeerAPI {
   contentClient: ContentClient
   logger: ILoggerComponent.ILogger
-  signatureFetcher: IFetchComponent
 
   constructor() {
-    this.signatureFetcher = createFetchComponent()
     this.contentClient = createContentClient({
       url: `${PEER_URL}/content`,
       fetcher: createFetchComponent(),

--- a/src/middleware/authentication.canonical-signer.spec.ts
+++ b/src/middleware/authentication.canonical-signer.spec.ts
@@ -1,0 +1,147 @@
+import { Request } from 'express'
+import { Authenticator, AuthIdentity, IdentityType } from '@dcl/crypto'
+import { createUnsafeIdentity } from '@dcl/crypto/dist/crypto'
+import { AUTH_CHAIN_HEADER_PREFIX, decodeAuthChain } from './authentication'
+
+// Header names are spelled out rather than imported from the middleware package so this spec is
+// identical before and after the migration, which is what makes the before/after comparison valid.
+const AUTH_TIMESTAMP_HEADER = 'x-identity-timestamp'
+const AUTH_METADATA_HEADER = 'x-identity-metadata'
+const SCENE_SIGNER = 'decentraland-kernel-scene'
+const PATH = '/test'
+
+type Identity = { authChain: AuthIdentity; ephemeralIdentity: IdentityType }
+
+async function createTestIdentity(): Promise<Identity> {
+  const ephemeralIdentity = createUnsafeIdentity()
+  const realAccount = createUnsafeIdentity()
+  const authChain = await Authenticator.initializeAuthChain(
+    realAccount.address,
+    ephemeralIdentity,
+    10,
+    async (message) => Authenticator.createSignature(realAccount, message)
+  )
+
+  return { authChain, ephemeralIdentity }
+}
+
+/** Signs `payload` with a real ephemeral chain and delivers `metadata` byte-for-byte as given. */
+function requestSignedOver(
+  payload: string,
+  metadata: Record<string, unknown>,
+  identity: Identity,
+  timestamp: number
+): Request {
+  const chain = Authenticator.signPayload(
+    {
+      ephemeralIdentity: identity.ephemeralIdentity,
+      expiration: new Date(),
+      authChain: identity.authChain.authChain,
+    },
+    payload
+  )
+
+  const headers: Record<string, string> = {}
+  chain.forEach((link, index) => {
+    headers[`${AUTH_CHAIN_HEADER_PREFIX}${index}`] = JSON.stringify(link)
+  })
+  headers[AUTH_TIMESTAMP_HEADER] = String(timestamp)
+  headers[AUTH_METADATA_HEADER] = JSON.stringify(metadata)
+
+  return ({ headers, method: 'GET', path: PATH } as unknown) as Request
+}
+
+/**
+ * Signs the canonical ADR-44 payload, which is lowercased before signing, so a mixed-case `signer`
+ * travels with a genuinely valid signature — the signature only ever bound the lowercased form. This
+ * is the attack itself, not a mock: `verify` runs for real and the signature really does check out.
+ */
+function signedRequest(
+  metadata: Record<string, unknown>,
+  identity: Identity
+): Request {
+  const timestamp = Date.now()
+  // authentication.ts verifies against `/${API_VERSION}${req.path}`, so the signed path carries the
+  // same prefix the middleware will rebuild.
+  const payload = [
+    'GET',
+    `/v1${PATH}`,
+    String(timestamp),
+    JSON.stringify(metadata),
+  ]
+    .join(':')
+    .toLowerCase()
+
+  return requestSignedOver(payload, metadata, identity, timestamp)
+}
+
+/** Signs the pre-ADR-44 `method:path` payload, without a timestamp or metadata. */
+function legacySignedRequest(
+  metadata: Record<string, unknown>,
+  identity: Identity
+): Request {
+  const payload = `GET:${PATH}`.toLowerCase()
+
+  return requestSignedOver(payload, metadata, identity, Date.now())
+}
+
+describe('decodeAuthChain with a real signature', () => {
+  let identity: Identity
+
+  beforeEach(async () => {
+    identity = await createTestIdentity()
+  })
+
+  describe('when the canonical scene signer was signed but a mixed-case spelling is delivered', () => {
+    it('should reject the request instead of accepting it as a directly user-signed one', async () => {
+      const request = signedRequest(
+        { signer: 'Decentraland-Kernel-Scene' },
+        identity
+      )
+
+      await expect(decodeAuthChain(request)).rejects.toThrow(
+        'Invalid signature'
+      )
+    })
+  })
+
+  describe('when a pre-ADR-44 signature arrives', () => {
+    it('should authenticate through the temporary legacy fallback', async () => {
+      const request = legacySignedRequest({}, identity)
+
+      await expect(decodeAuthChain(request)).resolves.toBe(
+        Authenticator.ownerAddress(identity.authChain.authChain).toLowerCase()
+      )
+    })
+  })
+
+  describe('when the canonical scene signer is delivered exactly as signed', () => {
+    it('should keep rejecting it as a scene-originated request', async () => {
+      const request = signedRequest({ signer: SCENE_SIGNER }, identity)
+
+      await expect(decodeAuthChain(request)).rejects.toThrow(
+        'Invalid signature'
+      )
+    })
+  })
+
+  describe('when the request carries no signer at all', () => {
+    it('should resolve to the verified owner address', async () => {
+      const request = signedRequest({}, identity)
+
+      await expect(decodeAuthChain(request)).resolves.toBe(
+        Authenticator.ownerAddress(identity.authChain.authChain).toLowerCase()
+      )
+    })
+  })
+
+  describe('when a padded scene signer is delivered', () => {
+    it('should reject it as non-canonical metadata', async () => {
+      const request = signedRequest({ signer: ` ${SCENE_SIGNER}` }, identity)
+
+      await expect(decodeAuthChain(request)).rejects.toThrow(
+        'Invalid signature'
+      )
+    })
+  })
+})

--- a/src/middleware/authentication.canonical-signer.spec.ts
+++ b/src/middleware/authentication.canonical-signer.spec.ts
@@ -85,14 +85,14 @@ function legacySignedRequest(
   return requestSignedOver(payload, metadata, identity, Date.now())
 }
 
-describe('decodeAuthChain with a real signature', () => {
+describe('when decoding an authentication chain with a real signature', () => {
   let identity: Identity
 
   beforeEach(async () => {
     identity = await createTestIdentity()
   })
 
-  describe('when the canonical scene signer was signed but a mixed-case spelling is delivered', () => {
+  describe('and a mixed-case scene signer is delivered', () => {
     it('should reject the request instead of accepting it as a directly user-signed one', async () => {
       const request = signedRequest(
         { signer: 'Decentraland-Kernel-Scene' },
@@ -105,7 +105,7 @@ describe('decodeAuthChain with a real signature', () => {
     })
   })
 
-  describe('when a pre-ADR-44 signature arrives', () => {
+  describe('and a pre-ADR-44 signature arrives', () => {
     it('should authenticate through the temporary legacy fallback', async () => {
       const request = legacySignedRequest({}, identity)
 
@@ -115,7 +115,7 @@ describe('decodeAuthChain with a real signature', () => {
     })
   })
 
-  describe('when the canonical scene signer is delivered exactly as signed', () => {
+  describe('and the canonical scene signer is delivered exactly as signed', () => {
     it('should keep rejecting it as a scene-originated request', async () => {
       const request = signedRequest({ signer: SCENE_SIGNER }, identity)
 
@@ -125,7 +125,7 @@ describe('decodeAuthChain with a real signature', () => {
     })
   })
 
-  describe('when the request carries no signer at all', () => {
+  describe('and the request carries no signer', () => {
     it('should resolve to the verified owner address', async () => {
       const request = signedRequest({}, identity)
 
@@ -135,7 +135,7 @@ describe('decodeAuthChain with a real signature', () => {
     })
   })
 
-  describe('when a padded scene signer is delivered', () => {
+  describe('and a padded scene signer is delivered', () => {
     it('should reject it as non-canonical metadata', async () => {
       const request = signedRequest({ signer: ` ${SCENE_SIGNER}` }, identity)
 

--- a/src/middleware/authentication.spec.ts
+++ b/src/middleware/authentication.spec.ts
@@ -6,65 +6,75 @@ import { decodeAuthChain, SCENE_SIGNER } from './authentication'
 jest.mock('@dcl/crypto-middleware')
 jest.mock('@dcl/crypto')
 
-describe('decodeAuthChain', () => {
+describe('when decoding an authentication chain', () => {
   let mockRequest: Request
 
-  beforeEach(() => {
-    mockRequest = {
-      headers: {},
-      method: 'GET',
-      path: '/',
-    } as Request
-    const isValidAuthChain = Authenticator.isValidAuthChain as jest.Mock
-    const ownerAddress = Authenticator.ownerAddress as jest.Mock
-    isValidAuthChain.mockReturnValue(true)
-    ownerAddress.mockReturnValue('0x12345')
-  })
-
-  it('returns the verified address', async () => {
-    const verifyMock = verify as jest.Mock
-    verifyMock.mockResolvedValue({
-      auth: '0x12345',
-      authMetadata: {},
+  describe('and the authentication chain is valid', () => {
+    beforeEach(() => {
+      mockRequest = {
+        headers: {},
+        method: 'GET',
+        path: '/',
+      } as Request
+      const isValidAuthChain = Authenticator.isValidAuthChain as jest.Mock
+      const ownerAddress = Authenticator.ownerAddress as jest.Mock
+      isValidAuthChain.mockReturnValue(true)
+      ownerAddress.mockReturnValue('0x12345')
     })
 
-    await expect(decodeAuthChain(mockRequest)).resolves.toBe('0x12345')
-  })
+    describe('and ADR-44 verification succeeds without a scene signer', () => {
+      it('should return the verified address', async () => {
+        const verifyMock = verify as jest.Mock
+        verifyMock.mockResolvedValue({
+          auth: '0x12345',
+          authMetadata: {},
+        })
 
-  it('rejects scene-signed requests after verification', async () => {
-    const verifyMock = verify as jest.Mock
-    verifyMock.mockResolvedValue({
-      auth: '0x12345',
-      authMetadata: { signer: SCENE_SIGNER },
+        await expect(decodeAuthChain(mockRequest)).resolves.toBe('0x12345')
+      })
     })
 
-    await expect(decodeAuthChain(mockRequest)).rejects.toThrow(
-      'Invalid signature'
-    )
-  })
+    describe('and ADR-44 verification identifies a scene signer', () => {
+      it('should reject the request', async () => {
+        const verifyMock = verify as jest.Mock
+        verifyMock.mockResolvedValue({
+          auth: '0x12345',
+          authMetadata: { signer: SCENE_SIGNER },
+        })
 
-  it('accepts a legacy signature when verify rejects it', async () => {
-    const verifyMock = verify as jest.Mock
-    const validateSignatureMock = Authenticator.validateSignature as jest.Mock
-    verifyMock.mockRejectedValue(new Error('Expired signature'))
-    validateSignatureMock.mockResolvedValue({
-      ok: true,
+        await expect(decodeAuthChain(mockRequest)).rejects.toThrow(
+          'Invalid signature'
+        )
+      })
     })
 
-    await expect(decodeAuthChain(mockRequest)).resolves.toBe('0x12345')
-  })
+    describe('and ADR-44 verification fails but the legacy signature is valid', () => {
+      it('should return the legacy verified address', async () => {
+        const verifyMock = verify as jest.Mock
+        const validateSignatureMock = Authenticator.validateSignature as jest.Mock
+        verifyMock.mockRejectedValue(new Error('Expired signature'))
+        validateSignatureMock.mockResolvedValue({
+          ok: true,
+        })
 
-  it('reports both failures when neither signature scheme validates', async () => {
-    const verifyMock = verify as jest.Mock
-    const validateSignatureMock = Authenticator.validateSignature as jest.Mock
-    verifyMock.mockRejectedValue(new Error('Expired signature'))
-    validateSignatureMock.mockResolvedValue({
-      ok: false,
-      message: 'Invalid legacy signature',
+        await expect(decodeAuthChain(mockRequest)).resolves.toBe('0x12345')
+      })
     })
 
-    await expect(decodeAuthChain(mockRequest)).rejects.toThrow(
-      'Expired signature'
-    )
+    describe('and ADR-44 and legacy verification both fail', () => {
+      it('should report the ADR-44 failure', async () => {
+        const verifyMock = verify as jest.Mock
+        const validateSignatureMock = Authenticator.validateSignature as jest.Mock
+        verifyMock.mockRejectedValue(new Error('Expired signature'))
+        validateSignatureMock.mockResolvedValue({
+          ok: false,
+          message: 'Invalid legacy signature',
+        })
+
+        await expect(decodeAuthChain(mockRequest)).rejects.toThrow(
+          'Expired signature'
+        )
+      })
+    })
   })
 })

--- a/src/middleware/authentication.spec.ts
+++ b/src/middleware/authentication.spec.ts
@@ -1,14 +1,10 @@
 import { Request } from 'express'
 import { Authenticator } from '@dcl/crypto'
-import { verify } from '@dcl/platform-crypto-middleware'
-import {
-  INVALID_AUTH_CHAIN_MESSAGE,
-  MISSING_ETH_ADDRESS_ERROR,
-  decodeAuthChain,
-} from './authentication'
+import { verify } from '@dcl/crypto-middleware'
+import { decodeAuthChain, SCENE_SIGNER } from './authentication'
 
+jest.mock('@dcl/crypto-middleware')
 jest.mock('@dcl/crypto')
-jest.mock('@dcl/platform-crypto-middleware')
 
 describe('decodeAuthChain', () => {
   let mockRequest: Request
@@ -19,147 +15,56 @@ describe('decodeAuthChain', () => {
       method: 'GET',
       path: '/',
     } as Request
+    const isValidAuthChain = Authenticator.isValidAuthChain as jest.Mock
+    const ownerAddress = Authenticator.ownerAddress as jest.Mock
+    isValidAuthChain.mockReturnValue(true)
+    ownerAddress.mockReturnValue('0x12345')
   })
 
-  describe('when the auth chain is invalid', () => {
-    it('should throw an error for an invalid auth chain', async () => {
-      mockRequest.headers = {
-        'x-identity-auth-chain-0': '{"invalidPart": "data"}',
-      }
-
-      await expect(decodeAuthChain(mockRequest)).rejects.toThrow(
-        INVALID_AUTH_CHAIN_MESSAGE
-      )
+  it('returns the verified address', async () => {
+    const verifyMock = verify as jest.Mock
+    verifyMock.mockResolvedValue({
+      auth: '0x12345',
+      authMetadata: {},
     })
+
+    await expect(decodeAuthChain(mockRequest)).resolves.toBe('0x12345')
   })
 
-  describe('when the auth chain is valid', () => {
-    beforeEach(() => {
-      ;(Authenticator.isValidAuthChain as jest.Mock).mockReturnValue(true)
+  it('rejects scene-signed requests after verification', async () => {
+    const verifyMock = verify as jest.Mock
+    verifyMock.mockResolvedValue({
+      auth: '0x12345',
+      authMetadata: { signer: SCENE_SIGNER },
     })
 
-    afterEach(() => {
-      ;(Authenticator.isValidAuthChain as jest.Mock).mockRestore()
+    await expect(decodeAuthChain(mockRequest)).rejects.toThrow(
+      'Invalid signature'
+    )
+  })
+
+  it('accepts a legacy signature when verify rejects it', async () => {
+    const verifyMock = verify as jest.Mock
+    const validateSignatureMock = Authenticator.validateSignature as jest.Mock
+    verifyMock.mockRejectedValue(new Error('Expired signature'))
+    validateSignatureMock.mockResolvedValue({
+      ok: true,
     })
 
-    describe('and it is missing an ETH address', () => {
-      it('should throw an error with the missing ETH address message', async () => {
-        await expect(decodeAuthChain(mockRequest)).rejects.toThrow(
-          MISSING_ETH_ADDRESS_ERROR
-        )
-      })
+    await expect(decodeAuthChain(mockRequest)).resolves.toBe('0x12345')
+  })
+
+  it('reports both failures when neither signature scheme validates', async () => {
+    const verifyMock = verify as jest.Mock
+    const validateSignatureMock = Authenticator.validateSignature as jest.Mock
+    verifyMock.mockRejectedValue(new Error('Expired signature'))
+    validateSignatureMock.mockResolvedValue({
+      ok: false,
+      message: 'Invalid legacy signature',
     })
 
-    describe('and it has the ETH address defined', () => {
-      let validAddress = '0x12345'
-      beforeEach(() => {
-        ;(Authenticator.ownerAddress as jest.Mock).mockReturnValue(validAddress)
-      })
-
-      afterEach(() => {
-        ;(Authenticator.isValidAuthChain as jest.Mock).mockRestore()
-      })
-
-      describe('and the verify method does not throw an error', () => {
-        describe('and the auth metadata is not defined', () => {
-          beforeEach(() => {
-            ;(verify as jest.Mock).mockReturnValue(validAddress)
-          })
-
-          afterEach(() => {
-            ;(verify as jest.Mock).mockRestore()
-          })
-
-          it('should return the eth address without throwing an error', async () => {
-            const result = await decodeAuthChain(mockRequest)
-            expect(result).toBe(validAddress)
-            await expect(decodeAuthChain(mockRequest)).resolves.not.toThrow()
-          })
-        })
-
-        describe('and the auth metadata is defined', () => {
-          describe('and the signer is decentraland-kernel-scene', () => {
-            beforeEach(() => {
-              ;(verify as jest.Mock).mockReturnValue({
-                authMetadata: { signer: 'decentraland-kernel-scene' },
-              })
-            })
-
-            afterEach(() => {
-              ;(verify as jest.Mock).mockRestore()
-            })
-
-            it('should throw an error with the invalid signature message', async () => {
-              await expect(decodeAuthChain(mockRequest)).rejects.toThrow(
-                'Invalid signature'
-              )
-            })
-          })
-
-          describe('and the signer is not decentraland-kernel-scene', () => {
-            beforeEach(() => {
-              ;(verify as jest.Mock).mockReturnValue({
-                authMetadata: { signer: 'another signer' },
-              })
-            })
-
-            afterEach(() => {
-              ;(verify as jest.Mock).mockRestore()
-            })
-
-            it('should return the eth address without throwing an error', async () => {
-              const result = await decodeAuthChain(mockRequest)
-              expect(result).toBe(validAddress)
-              await expect(decodeAuthChain(mockRequest)).resolves.not.toThrow()
-            })
-          })
-        })
-      })
-
-      describe('and the verify method throws an error', () => {
-        beforeEach(() => {
-          ;(verify as jest.Mock).mockRejectedValue('Error')
-        })
-
-        afterEach(() => {
-          ;(verify as jest.Mock).mockRestore()
-        })
-
-        describe('and the validateSignature function does not throw an error', () => {
-          beforeEach(() => {
-            ;(Authenticator.validateSignature as jest.Mock).mockReturnValue({
-              ok: true,
-            })
-          })
-
-          afterEach(() => {
-            ;(Authenticator.validateSignature as jest.Mock).mockRestore()
-          })
-          it('should return the eth address without throwing an error', async () => {
-            const result = await decodeAuthChain(mockRequest)
-            expect(result).toBe(validAddress)
-            await expect(decodeAuthChain(mockRequest)).resolves.not.toThrow()
-          })
-        })
-
-        describe('and the validateSignature method throws an error', () => {
-          let error: string
-          beforeEach(() => {
-            error = 'validateSignature failed'
-            ;(Authenticator.validateSignature as jest.Mock).mockReturnValue({
-              ok: false,
-              message: error,
-            })
-          })
-
-          afterEach(() => {
-            ;(Authenticator.validateSignature as jest.Mock).mockRestore()
-          })
-          it('should throw the error', async () => {
-            await expect(decodeAuthChain(mockRequest)).rejects.toThrow(error)
-          })
-        })
-      })
-    })
+    await expect(decodeAuthChain(mockRequest)).rejects.toThrow(
+      'Expired signature'
+    )
   })
 })

--- a/src/middleware/authentication.ts
+++ b/src/middleware/authentication.ts
@@ -1,17 +1,18 @@
 import { Request, Response, NextFunction } from 'express'
 import { env } from 'decentraland-commons'
 import { AuthLink, Authenticator } from '@dcl/crypto'
-import { verify } from '@dcl/platform-crypto-middleware'
-import { isEIP1664AuthChain } from '@dcl/platform-crypto-middleware/dist/verify'
+import { AUTH_CHAIN_HEADER_PREFIX, verify } from '@dcl/crypto-middleware'
+import { isEIP1654AuthChain } from '@dcl/crypto-middleware/dist/verify'
 import { server } from 'decentraland-server'
 import { STATUS_CODES } from '../common/HTTPError'
 import { isErrorWithMessage } from '../utils/errors'
 import { peerAPI } from '../ethereum/api/peer'
 
 const API_VERSION = env.get('API_VERSION', 'v1')
-export const AUTH_CHAIN_HEADER_PREFIX = 'x-identity-auth-chain-'
-export const MISSING_ETH_ADDRESS_ERROR = 'Missing ETH address in auth chain'
-export const INVALID_AUTH_CHAIN_MESSAGE = 'Invalid auth chain'
+export { AUTH_CHAIN_HEADER_PREFIX }
+export const AUTH_METADATA_HEADER = 'x-identity-metadata'
+/** The `signer` an explorer sets on an auth chain signed on a scene's behalf. */
+export const SCENE_SIGNER = 'decentraland-kernel-scene'
 
 export type AuthRequest = Request & {
   auth: Record<string, string | number | boolean> & {
@@ -61,84 +62,97 @@ const getAuthenticationMiddleware = <
   }
 }
 
+/**
+ * Checks for a scene signer before entering the legacy signature fallback.
+ *
+ * Legacy `method:path` signatures do not bind metadata, so this must read and normalize the raw
+ * header rather than relying on `verify()`'s parsed result.
+ */
+function declaresSceneSigner(req: Request): boolean {
+  const raw = req.headers[AUTH_METADATA_HEADER]
+  if (typeof raw !== 'string') {
+    return false
+  }
+
+  try {
+    const metadata = JSON.parse(raw) as { signer?: unknown } | null
+    return (
+      typeof metadata?.signer === 'string' &&
+      metadata.signer.trim().toLowerCase() === SCENE_SIGNER
+    )
+  } catch {
+    return false
+  }
+}
+
 export async function decodeAuthChain(req: Request): Promise<string> {
   const authChain = buildAuthChain(req)
-  let ethAddress: string | null = null
-  let errorMessage: string | null = null
 
   if (!Authenticator.isValidAuthChain(authChain)) {
-    errorMessage = INVALID_AUTH_CHAIN_MESSAGE
-  } else {
-    ethAddress = Authenticator.ownerAddress(authChain)
+    throw new Error('Invalid auth chain')
+  }
 
-    if (!ethAddress) {
-      errorMessage = MISSING_ETH_ADDRESS_ERROR
-    } else {
-      try {
-        const data = await verify(
-          req.method,
-          `/${API_VERSION}${req.path}`,
-          req.headers,
-          {
-            fetcher: peerAPI.signatureFetcher,
-            expiration: 1000 * 60 * 30, // 30 minutes
-          }
-        )
+  const ethAddress = Authenticator.ownerAddress(authChain)
+  if (!ethAddress) {
+    throw new Error('Missing ETH address in auth chain')
+  }
 
-        if (
-          data.authMetadata &&
-          typeof data.authMetadata === 'object' &&
-          'signer' in data.authMetadata &&
-          data.authMetadata.signer === 'decentraland-kernel-scene'
-        ) {
-          errorMessage = 'Invalid signature'
-        }
-      } catch (error) {
-        errorMessage = isErrorWithMessage(error)
-          ? `"verify" method failed with error: ${error.message}`
-          : 'Unknown'
-        try {
-          await validateSignature(req, authChain)
-          errorMessage = null // clear error if it has success
-        } catch (error) {
-          errorMessage = `${errorMessage}.
-          "validateSignature" method failed with error: ${
-            isErrorWithMessage(error) ? error.message : 'Unknown'
-          }`
-        }
+  if (declaresSceneSigner(req)) {
+    throw new Error('Invalid signature')
+  }
+
+  try {
+    const data = await verify(
+      req.method,
+      `/${API_VERSION}${req.path}`,
+      req.headers,
+      {
+        expiration: 1000 * 60 * 30, // 30 minutes
       }
+    )
+
+    if (data.authMetadata.signer === SCENE_SIGNER) {
+      throw new Error('Invalid signature')
+    }
+
+    return data.auth
+  } catch (error) {
+    try {
+      await validateSignature(req, authChain)
+      return ethAddress.toLowerCase()
+    } catch (fallbackError) {
+      const verifyError = isErrorWithMessage(error) ? error.message : 'Unknown'
+      const legacyError = isErrorWithMessage(fallbackError)
+        ? fallbackError.message
+        : 'Unknown'
+      throw new Error(
+        `"verify" method failed with error: ${verifyError}. ` +
+          `"validateSignature" method failed with error: ${legacyError}`
+      )
     }
   }
-
-  if (errorMessage) {
-    throw new Error(errorMessage)
-  }
-
-  return ethAddress!.toLowerCase()
 }
 
 /**
- * @deprecated use `verify` from '@dcl/platform-crypto-middleware', this function is mantained for retro-compatibility, but after we remove all the uses from the front-end should be removed
- * returns error message
+ * Temporary compatibility path for clients that still sign the deprecated `method:path` payload.
+ * Remove once all callers have moved to ADR-44 signed requests.
  */
 async function validateSignature(req: Request, authChain: AuthLink[]) {
-  // TODO: We are waiting for the final implementation of https://github.com/decentraland/decentraland-crypto-middleware in order to complete use it.
-  // For the time being, we need to reduce the number of request to the catalysts
   const endpoint = (req.method + ':' + req.path).toLowerCase()
-  if (isEIP1664AuthChain(authChain)) {
-    // We don't use the response, just want to make sure it does not blow up
-    await peerAPI.validateSignature({ authChain, timestamp: endpoint }) // We send the endpoint as the timestamp, yes
-  } else {
-    const res = await Authenticator.validateSignature(
-      endpoint,
-      authChain,
-      null as any,
-      Date.now()
-    )
+  if (isEIP1654AuthChain(authChain)) {
+    await peerAPI.validateSignature({ authChain, timestamp: endpoint })
+    return
+  }
 
-    if (!res.ok) {
-      throw new Error(res.message)
-    }
+  const result = await Authenticator.validateSignature(
+    endpoint,
+    authChain,
+    null as any,
+    Date.now()
+  )
+
+  if (!result.ok) {
+    throw new Error(result.message)
   }
 }
 


### PR DESCRIPTION
## Summary

- migrate from `@dcl/platform-crypto-middleware` to `@dcl/crypto-middleware` 5.1.0
- reject scene-declared signed requests before the deprecated `method:path` fallback can accept them
- update signed-fetch test helpers and add real-signature canonical-signer coverage

## Security rationale

The legacy fallback does not bind timestamp or metadata. The scene-signer guard therefore deliberately parses the raw `x-identity-metadata` header before entering the `verify()`/fallback path. Do not refactor this guard to read `verify()` output: a failed v5 verification would then allow the fallback to clear the rejection.

## Validation

- `npm test -- --runInBand` (41 suites, 495 tests)
- `npm run build`
- targeted TSLint for changed authentication files

`npm run lint` still reports the repository's existing broad legacy lint backlog outside this change.
