### PR TITLE
feat: support status filter on GET /:address/collections

### DIFF
--- a/src/Collection/Collection.router.spec.ts
+++ b/src/Collection/Collection.router.spec.ts
@@ -65,7 +65,7 @@ import {
   SlotUsageCheque,
   SlotUsageChequeAttributes,
 } from '../SlotUsageCheque'
-import { CurationStatus } from '../Curation'
+import { CurationStatus, CurationStatusFilter } from '../Curation'
 import { ThirdPartyService } from '../ThirdParty/ThirdParty.service'
 import { ThirdParty } from '../ThirdParty/ThirdParty.types'
 import { isCommitteeMember } from '../Committee'
@@ -1515,6 +1515,79 @@ describe('Collection router', () => {
               isPublished: undefined,
             })
           })
+      })
+    })
+
+    describe('and sending a status query param', () => {
+      let approvedRemoteCollection: CollectionFragment
+      let notApprovedRemoteCollection: CollectionFragment
+
+      beforeEach(() => {
+        approvedRemoteCollection = {
+          ...collectionFragmentMock,
+          id: 'approved-remote-id',
+          isApproved: true,
+        }
+        notApprovedRemoteCollection = {
+          ...collectionFragmentMock,
+          id: 'not-approved-remote-id',
+          isApproved: false,
+        }
+        ;(collectionAPI.fetchCollectionsByAuthorizedUser as jest.Mock)
+          .mockReset()
+          .mockResolvedValueOnce([
+            approvedRemoteCollection,
+            notApprovedRemoteCollection,
+          ])
+        ;(Collection.findAll as jest.Mock).mockReturnValueOnce([
+          { ...dbCollection, collection_count: 1 },
+        ])
+        ;(Collection.findByThirdPartyIds as jest.Mock).mockReturnValueOnce([])
+        ;(ThirdPartyService.getThirdParties as jest.Mock).mockReturnValueOnce(
+          []
+        )
+      })
+
+      describe('and the status maps to non-approved collections', () => {
+        it('should call the findAll method with the status and only the non-approved remote ids', () => {
+          return server
+            .get(buildURL(`${url}?status=${CurationStatusFilter.REJECTED}`))
+            .set(createAuthHeaders('get', url))
+            .expect(200)
+            .then(() => {
+              expect(Collection.findAll).toHaveBeenCalledWith({
+                address: wallet.address,
+                limit: undefined,
+                offset: undefined,
+                sort: CollectionSort.CREATED_AT_DESC,
+                thirdPartyIds: [],
+                status: CurationStatusFilter.REJECTED,
+                remoteIds: [notApprovedRemoteCollection.id],
+                isPublished: undefined,
+              })
+            })
+        })
+      })
+
+      describe('and the status is approved', () => {
+        it('should call the findAll method with the status and only the approved remote ids', () => {
+          return server
+            .get(buildURL(`${url}?status=${CurationStatusFilter.APPROVED}`))
+            .set(createAuthHeaders('get', url))
+            .expect(200)
+            .then(() => {
+              expect(Collection.findAll).toHaveBeenCalledWith({
+                address: wallet.address,
+                limit: undefined,
+                offset: undefined,
+                sort: CollectionSort.CREATED_AT_DESC,
+                thirdPartyIds: [],
+                status: CurationStatusFilter.APPROVED,
+                remoteIds: [approvedRemoteCollection.id],
+                isPublished: undefined,
+              })
+            })
+        })
       })
     })
   })

--- a/src/Collection/Collection.router.ts
+++ b/src/Collection/Collection.router.ts
@@ -346,7 +346,7 @@ export class CollectionRouter extends Router {
     req: AuthRequest
   ): Promise<PaginatedResponse<FullCollection> | FullCollection[]> => {
     const { page, limit } = getPaginationParams(req)
-    const { is_published, sort, q, type } = req.query
+    const { is_published, sort, q, type, status } = req.query
     const eth_address = server.extractFromReq(req, 'address')
     const auth_address = req.auth.ethAddress
 
@@ -362,6 +362,18 @@ export class CollectionRouter extends Router {
       eth_address
     )
 
+    // When filtering by status, the query expects only the remote ids whose on-chain approval
+    // state matches that status (as getCollections does via the filtered graph query).
+    const { isApproved } = toRemoteWhereCondition({
+      status: status as CurationStatusFilter,
+    })
+    const remoteCollectionsForQuery =
+      isApproved === undefined
+        ? authorizedRemoteCollections
+        : authorizedRemoteCollections.filter(
+            (remoteCollection) => remoteCollection.isApproved === isApproved
+          )
+
     const allCollectionsWithCount = await this.service.getCollections(
       {
         q: q as string,
@@ -370,8 +382,9 @@ export class CollectionRouter extends Router {
         address: eth_address,
         sort: (sort as CollectionSort) || CollectionSort.CREATED_AT_DESC,
         type: type as CollectionTypeFilter,
+        status: status as CurationStatusFilter,
         isPublished: is_published ? is_published === 'true' : undefined,
-        remoteIds: authorizedRemoteCollections.map(
+        remoteIds: remoteCollectionsForQuery.map(
           (remoteCollection) => remoteCollection.id
         ),
       },


### PR DESCRIPTION
## What

- The address-scoped collections endpoint (`GET /:address/collections`) now honors the `status` query param (`rejected`, `under_review`, `approved`, …), returning only the creator's collections in that curation state instead of silently ignoring the filter.
- Sending no `status` behaves exactly as before.

## Why

The new creator UI's collection status filters (Submitted / Rejected chips and the rejected-count badge) send `status` on this endpoint, but only the committee-facing `GET /collections` supported it — so those filters returned every collection.

## How to test

1. As an authenticated creator with published collections in different curation states, request `GET /:address/collections?page=1&limit=20&status=rejected`.
2. Only collections with a rejected curation are returned, and the pagination `total` reflects the filtered count.
3. Repeat without `status` and confirm the full, unfiltered list is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)